### PR TITLE
fix: improve ILRepack assembly inclusion filter in Repack.Tool.Test

### DIFF
--- a/Tests/Repack.Tool.Test/ILRepack.targets
+++ b/Tests/Repack.Tool.Test/ILRepack.targets
@@ -10,8 +10,8 @@
       <InputAssemblies Include="@(ReferenceCopyLocalPaths)" />
 
       <FilterAssemblies Include="$(ProjectName)" />
-      <FilterAssemblies Include="xunit.v3" />
       <FilterAssemblies Include="TestLibA" />
+      <FilterAssemblies Include="xunit" />
 
       <LibraryPath Include="%(InputAssemblies.Directory)" />
     </ItemGroup>


### PR DESCRIPTION
- **fix: include main assembly name in filter**
- **fix: change FilterAssembly rule for xunit.v3 -> xunit**
