### PR TITLE
build: add project reference to ILRepack.Tool.MSBuild.Task in Repack.Tool.Test

### DIFF
--- a/Tests/Repack.Tool.Test/Repack.Tool.Test.csproj
+++ b/Tests/Repack.Tool.Test/Repack.Tool.Test.csproj
@@ -38,7 +38,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\TestLibA\TestLibA.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\..\ILRepack.Tool.MSBuild.Task\ILRepack.Tool.MSBuild.Task.csproj" PrivateAssets="all" IncludeAssets="all" />
   </ItemGroup>
+
 
   <Import Project="..\..\ILRepack.Tool.MSBuild.Task\build\KageKirin.ILRepack.Tool.MSBuild.Task.targets" />
   <Import Project="ILRepack.targets" />


### PR DESCRIPTION
note: added with `PrivateAssets="all"` and `IncludeAssets="all"` so that
      the assembly and targets are copied into the build folder.
