### PR TITLE
fix: set `ILRepack` class property default values to fix warning CS8618

### DIFF
--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -237,7 +237,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task
         set { _FilterAssemblies = value; }
     }
 
-    private Microsoft.Build.Framework.ITaskItem[] _ImportAttributeAssemblies;
+    private Microsoft.Build.Framework.ITaskItem[] _ImportAttributeAssemblies = [];
 
     public virtual Microsoft.Build.Framework.ITaskItem[] ImportAttributeAssemblies
     {

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -245,7 +245,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task
         set { _ImportAttributeAssemblies = value; }
     }
 
-    private Microsoft.Build.Framework.ITaskItem[] _InternalizeAssemblies;
+    private Microsoft.Build.Framework.ITaskItem[] _InternalizeAssemblies = [];
 
     public virtual Microsoft.Build.Framework.ITaskItem[] InternalizeAssemblies
     {

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -197,7 +197,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task
         set { _InputAssemblies = value; }
     }
 
-    private Microsoft.Build.Framework.ITaskItem[] _LibraryPaths;
+    private Microsoft.Build.Framework.ITaskItem[] _LibraryPaths = [];
 
     public virtual Microsoft.Build.Framework.ITaskItem[] LibraryPaths
     {

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -205,7 +205,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task
         set { _LibraryPaths = value; }
     }
 
-    private Microsoft.Build.Framework.ITaskItem[] _InternalizeExclude;
+    private Microsoft.Build.Framework.ITaskItem[] _InternalizeExclude = [];
 
     public virtual Microsoft.Build.Framework.ITaskItem[] InternalizeExclude
     {

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -253,7 +253,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task
         set { _InternalizeAssemblies = value; }
     }
 
-    private Microsoft.Build.Framework.ITaskItem[] _RepackDropAttributes;
+    private Microsoft.Build.Framework.ITaskItem[] _RepackDropAttributes = [];
 
     public virtual Microsoft.Build.Framework.ITaskItem[] RepackDropAttributes
     {

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -261,7 +261,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task
         set { _RepackDropAttributes = value; }
     }
 
-    private Microsoft.Build.Framework.ITaskItem[] _AllowedDuplicateTypes;
+    private Microsoft.Build.Framework.ITaskItem[] _AllowedDuplicateTypes = [];
 
     public virtual Microsoft.Build.Framework.ITaskItem[] AllowedDuplicateTypes
     {

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -53,7 +53,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task
         set { _RenameInternalized = value; }
     }
 
-    private string _TargetKind;
+    private string _TargetKind = string.Empty;
 
     public virtual string TargetKind
     {

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -181,7 +181,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task
         set { _ZeroPEKind = value; }
     }
 
-    private string _Version;
+    private string _Version = string.Empty;
 
     public virtual string Version
     {

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -229,7 +229,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task
         set { _LogFile = value; }
     }
 
-    private Microsoft.Build.Framework.ITaskItem[] _FilterAssemblies;
+    private Microsoft.Build.Framework.ITaskItem[] _FilterAssemblies = [];
 
     public virtual Microsoft.Build.Framework.ITaskItem[] FilterAssemblies
     {

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -189,7 +189,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task
         set { _Version = value; }
     }
 
-    private Microsoft.Build.Framework.ITaskItem[] _InputAssemblies;
+    private Microsoft.Build.Framework.ITaskItem[] _InputAssemblies = [];
 
     public virtual Microsoft.Build.Framework.ITaskItem[] InputAssemblies
     {


### PR DESCRIPTION
- **fix: set default value for property `_TargetKind` to fix warning CS8618**
- **fix: set default value for property `_Version` to fix warning CS8618**
- **fix: set default value for property `_InputAssemblies` to fix warning CS8618**
- **fix: set default value for property `_LibraryPaths` to fix warning CS8618**
- **fix: set default value for property `_InternalizeExclude` to fix warning CS8618**
- **fix: set default value for property `_FilterAssemblies` to fix warning CS8618**
- **fix: set default value for property `_ImportAttributeAssemblies` to fix warning CS8618**
- **fix: set default value for property `_InternalizeAssemblies` to fix warning CS8618**
- **fix: set default value for property `_RepackDropAttributes` to fix warning CS8618**
- **fix: set default value for property `_AllowedDuplicateTypes` to fix warning CS8618**
