### PR TITLE
build: remove incompatible build properties from ILRepack.Tool.MSBuild.Task

### DIFF
--- a/ILRepack.Tool.MSBuild.Task/ILRepack.Tool.MSBuild.Task.csproj
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.Tool.MSBuild.Task.csproj
@@ -11,7 +11,6 @@
     <IsPublishable>true</IsPublishable>
     <PackRelease>true</PackRelease>
     <PublishRelease>true</PublishRelease>
-    <SelfContained>true</SelfContained>
     <DebugType>embedded</DebugType>
   </PropertyGroup>
 

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.Tool.MSBuild.Task.csproj
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.Tool.MSBuild.Task.csproj
@@ -29,8 +29,8 @@
          By convention, the .NET SDK will look for build\<Package Id>.props and build\<Package Id>.targets
          for automatic inclusion in the build.
     -->
-    <Content Include="$(MSBuildThisFileDirectory)build\KageKirin.ILRepack.Tool.MSBuild.Task.targets" PackagePath="build\" Link="build\KageKirin.ILRepack.Tool.MSBuild.Task.targets" Pack="true" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="$(MSBuildThisFileDirectory)build\KageKirin.ILRepack.Tool.MSBuild.Task.targets" PackagePath="tools\" Link="tools\KageKirin.ILRepack.Tool.MSBuild.Task.targets" Pack="true" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(MSBuildThisFileDirectory)build\KageKirin.ILRepack.Tool.MSBuild.Task.targets" PackagePath="build" Link="build\KageKirin.ILRepack.Tool.MSBuild.Task.targets" Pack="true" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(MSBuildThisFileDirectory)build\KageKirin.ILRepack.Tool.MSBuild.Task.targets" PackagePath="tools" Link="tools\KageKirin.ILRepack.Tool.MSBuild.Task.targets" Pack="true" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.Tool.MSBuild.Task.csproj
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.Tool.MSBuild.Task.csproj
@@ -11,7 +11,6 @@
     <IsPublishable>true</IsPublishable>
     <PackRelease>true</PackRelease>
     <PublishRelease>true</PublishRelease>
-    <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
     <DebugType>embedded</DebugType>
   </PropertyGroup>


### PR DESCRIPTION
- **build: remove PublishSingleFile flag**
- **build: remove SelfContained flag**
- **build: remove trailing backslash for PackagePath**
