### PR TITLE
feat: implement ILRepack.Lib.MSBuild.Task

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>ILRepack.Lib.MsBuild.Task</AssemblyName>
+    <IsPackable>true</IsPackable>
+    <IsPublishable>true</IsPublishable>
+    <PackRelease>true</PackRelease>
+    <PublishRelease>true</PublishRelease>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Label="build metadata">
+    <PackageId>KageKirin.ILRepack.Lib.MSBuild.Task</PackageId>
+    <Title>ILRepack.Lib.MSBuild.Task</Title>
+    <Description>MSBuild Task to run `ILRepack` over a freshly compiled assembly, in order to infuse it with select IL code of its dependencies.</Description>
+    <PackageTags>il;ilrepack;ilmerge</PackageTags>
+    <PackageIcon>Icon.png</PackageIcon>
+    <PackageIconUrl>https://raw.github.com/KageKirin/ILRepack.MSBuild.Task/main/Icon.png</PackageIconUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      These lines pack the build props/targets files to the `build` folder in the generated package.
+         By convention, the .NET SDK will look for build\<Package Id>.props and build\<Package Id>.targets
+         for automatic inclusion in the build.
+    -->
+    <Content Include="$(MSBuildThisFileDirectory)build\KageKirin.ILRepack.Lib.MSBuild.Task.targets" PackagePath="build\" Link="build\KageKirin.ILRepack.Lib.MSBuild.Task.targets" Pack="true" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(MSBuildThisFileDirectory)build\KageKirin.ILRepack.Lib.MSBuild.Task.targets" PackagePath="tools\" Link="tools\KageKirin.ILRepack.Lib.MSBuild.Task.targets" Pack="true" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="all" />
+    <PackageReference Include="ILRepack.Lib" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="all" />
+    <PackageReference Include="ILRepack" PrivateAssets="all" />
     <PackageReference Include="ILRepack.Lib" PrivateAssets="all" />
   </ItemGroup>
 

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
@@ -14,6 +14,7 @@
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
     <DebugType>embedded</DebugType>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Label="build metadata">
@@ -38,8 +39,21 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="all" />
-    <PackageReference Include="ILRepack" PrivateAssets="all" />
-    <PackageReference Include="ILRepack.Lib" PrivateAssets="all" />
+    <PackageReference Include="ILRepack" PrivateAssets="all" IncludeAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="ILRepack.Lib" PrivateAssets="all" IncludeAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ILRepack.Tool.MSBuild.Task\ILRepack.Tool.MSBuild.Task.csproj" PrivateAssets="all" IncludeAssets="all" />
+  </ItemGroup>
+
+  <Import Project="..\ILRepack.Tool.MSBuild.Task\build\KageKirin.ILRepack.Tool.MSBuild.Task.targets" />
+  <Import Project="ILRepack.targets" />
+
+
+  <Target Name="INFO" BeforeTargets="Compile">
+    <Message Text="PkgILRepack $(PkgILRepack)" Importance="high" />
+    <Message Text="PkgILRepack_Lib $(PkgILRepack_Lib)" Importance="high" />
+  </Target>
 
 </Project>

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.targets
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.targets
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="ILRepacker" AfterTargets="Compile" DependsOnTargets="ResolveAssemblyReferences">
+
+    <Message Text="Repacking $(IntermediateOutputPath)" Importance="high" />
+
+    <ItemGroup>
+      <MainAssembly Include="$(IntermediateOutputPath)$(TargetFileName)" />
+
+      <InputAssemblies Include="@(ReferenceCopyLocalPaths)" />
+      <InputAssemblies Include="$(PkgILRepack_Lib)\**\*.dll" />
+
+      <FilterAssemblies Include="$(AssemblyName)" />
+      <FilterAssemblies Include="ILRepack.dll" />
+      <FilterAssemblies Include="ILRepack$" />
+
+      <LibraryPath Include="%(InputAssemblies.Directory)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <DoNotInternalizeAssemblies Include="@(MainAssembly)" />
+    </ItemGroup>
+
+    <Message Text="Repacking assemblies in $(IntermediateOutputPath): @(InputAssemblies->'%(Identity)', ' ') into @(MainAssembly->'%(Identity)')" Importance="high" />
+
+    <ILRepack
+      Parallel="false"
+      DebugInfo="true"
+      Verbose="true"
+      Internalize="true"
+      RenameInternalized="false"
+      InputAssemblies="@(MainAssembly);@(InputAssemblies)"
+      InternalizeExclude="@(DoNotInternalizeAssemblies)"
+      FilterAssemblies="@(FilterAssemblies)"
+
+      OutputFile="@(MainAssembly)"
+      LogFile="$(OutputPath)$(AssemblyName).ilrepack.log"
+    />
+
+  </Target>
+
+
+</Project>

--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -222,6 +222,27 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
             $"ILRepackLib: InputAssemblies (filtered): {string.Join("\n", InputAssemblies.Distinct().Select(f => f.ItemSpec))}"
         );
 
+        foreach (var inputAssembly in InputAssemblies.Select(f => f.ItemSpec))
+        {
+            if (string.IsNullOrEmpty(inputAssembly))
+            {
+                Log.LogError("ILRepackLib: InputAssemblies contains null/empty input assembly");
+                continue;
+            }
+
+            if (File.Exists(inputAssembly))
+            {
+                Log.LogMessage(
+                    MessageImportance.High,
+                    $"ILRepackLib: InputAssemblies `{inputAssembly}` exists"
+                );
+            }
+            else
+            {
+                Log.LogError($"ILRepackLib: InputAssemblies `{inputAssembly}` does not exist!");
+            }
+        }
+
         if (LibraryPaths is not null && LibraryPaths.Length > 0)
             repackOptions.SearchDirectories = LibraryPaths.Select(item => item.ItemSpec).Distinct();
         else

--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -122,28 +122,29 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
             )
             : OutputFile.ItemSpec;
 
-        RepackOptions repackOptions = new();
-
-        repackOptions.Parallel = Parallel;
-        repackOptions.DebugInfo = DebugInfo;
-        repackOptions.LogVerbose = Verbose;
-        repackOptions.Internalize = Internalize;
-        repackOptions.RenameInternalized = RenameInternalized;
-        repackOptions.AllowWildCards = Wildcards;
-        repackOptions.DelaySign = DelaySign;
-        repackOptions.ExcludeInternalizeSerializable = ExcludeInternalizeSerializable;
-        repackOptions.UnionMerge = Union;
-        repackOptions.AllowAllDuplicateTypes = AllowDup;
-        repackOptions.AllowDuplicateResources = AllowDuplicateResources;
-        repackOptions.NoRepackRes = NoRepackRes;
-        repackOptions.CopyAttributes = CopyAttrs;
-        repackOptions.AllowMultipleAssemblyLevelAttributes = AllowMultiple;
-        repackOptions.KeepOtherVersionReferences = KeepOtherVersionReferences;
-        repackOptions.PreserveTimestamp = PreserveTimestamp;
-        repackOptions.SkipConfigMerge = SkipConfig;
-        repackOptions.MergeIlLinkerFiles = ILLink;
-        repackOptions.XmlDocumentation = XmlDocs;
-        repackOptions.AllowZeroPeKind = ZeroPEKind;
+        RepackOptions repackOptions = new()
+        {
+            Parallel = Parallel,
+            DebugInfo = DebugInfo,
+            LogVerbose = Verbose,
+            Internalize = Internalize,
+            RenameInternalized = RenameInternalized,
+            AllowWildCards = Wildcards,
+            DelaySign = DelaySign,
+            ExcludeInternalizeSerializable = ExcludeInternalizeSerializable,
+            UnionMerge = Union,
+            AllowAllDuplicateTypes = AllowDup,
+            AllowDuplicateResources = AllowDuplicateResources,
+            NoRepackRes = NoRepackRes,
+            CopyAttributes = CopyAttrs,
+            AllowMultipleAssemblyLevelAttributes = AllowMultiple,
+            KeepOtherVersionReferences = KeepOtherVersionReferences,
+            PreserveTimestamp = PreserveTimestamp,
+            SkipConfigMerge = SkipConfig,
+            MergeIlLinkerFiles = ILLink,
+            XmlDocumentation = XmlDocs,
+            AllowZeroPeKind = ZeroPEKind,
+        };
 
         if (!string.IsNullOrWhiteSpace(TargetKind))
             repackOptions.TargetKind = (ILRepacking.ILRepack.Kind)

--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -114,7 +114,12 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
         bool needTempOutputAssembly = InputAssemblies[0].ItemSpec == OutputFile.ItemSpec;
         string outputAssembly = needTempOutputAssembly
-            ? Path.GetTempFileName()
+            ? Path.Combine(
+                Path.GetDirectoryName(OutputFile.ItemSpec),
+                Path.GetFileNameWithoutExtension(OutputFile.ItemSpec)
+                    + ".Repack"
+                    + Path.GetExtension(OutputFile.ItemSpec)
+            )
             : OutputFile.ItemSpec;
 
         RepackOptions repackOptions = new();

--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -1,0 +1,328 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using ILRepacking;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+#nullable enable
+
+namespace KageKirin.ILRepack.Lib.MSBuild.Task;
+
+public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
+{
+    public virtual bool Parallel { get; set; }
+
+    public virtual bool DebugInfo { get; set; }
+
+    public virtual bool Verbose { get; set; }
+
+    public virtual bool Internalize { get; set; }
+
+    public virtual bool RenameInternalized { get; set; }
+
+    public virtual string TargetKind { get; set; } = string.Empty;
+
+    public virtual bool Wildcards { get; set; }
+
+    public virtual bool DelaySign { get; set; }
+
+    public virtual bool ExcludeInternalizeSerializable { get; set; }
+
+    public virtual bool Union { get; set; }
+
+    public virtual bool AllowDup { get; set; }
+
+    public virtual bool AllowDuplicateResources { get; set; }
+
+    public virtual bool NoRepackRes { get; set; }
+
+    public virtual bool CopyAttrs { get; set; }
+
+    public virtual bool AllowMultiple { get; set; }
+
+    public virtual bool KeepOtherVersionReferences { get; set; }
+
+    public virtual bool PreserveTimestamp { get; set; }
+
+    public virtual bool SkipConfig { get; set; }
+
+    public virtual bool ILLink { get; set; }
+
+    public virtual bool XmlDocs { get; set; }
+
+    public virtual bool ZeroPEKind { get; set; }
+
+    public virtual string Version { get; set; } = string.Empty;
+
+    public virtual Microsoft.Build.Framework.ITaskItem[] InputAssemblies { get; set; } = [];
+
+    public virtual Microsoft.Build.Framework.ITaskItem[] LibraryPaths { get; set; } = [];
+
+    public virtual Microsoft.Build.Framework.ITaskItem[] InternalizeExclude { get; set; } = [];
+
+    public virtual Microsoft.Build.Framework.ITaskItem OutputFile { get; set; } = default;
+
+    public virtual Microsoft.Build.Framework.ITaskItem LogFile { get; set; } = default;
+
+    public virtual Microsoft.Build.Framework.ITaskItem[] FilterAssemblies { get; set; } = [];
+
+    public virtual Microsoft.Build.Framework.ITaskItem[] ImportAttributeAssemblies { get; set; } =
+        [];
+
+    public virtual Microsoft.Build.Framework.ITaskItem[] InternalizeAssemblies { get; set; } = [];
+
+    public virtual Microsoft.Build.Framework.ITaskItem[] RepackDropAttributes { get; set; } = [];
+
+    public virtual Microsoft.Build.Framework.ITaskItem[] AllowedDuplicateTypes { get; set; } = [];
+
+    public virtual Microsoft.Build.Framework.ITaskItem KeyFile { get; set; } = default;
+
+    public virtual Microsoft.Build.Framework.ITaskItem KeyContainer { get; set; } = default;
+
+    public virtual int Timeout { get; set; }
+
+    public virtual bool Success { get; set; }
+
+    public override bool Execute()
+    {
+        Log.LogMessage(MessageImportance.High, "ILRepackLib: preparing inputs");
+
+        if (OutputFile is null || string.IsNullOrWhiteSpace(OutputFile.ItemSpec))
+        {
+            Log.LogError("ILRepackLib: OutputFile must be set");
+            return false;
+        }
+
+        if (
+            InputAssemblies is null
+            || InputAssemblies.Length == 0
+            || string.IsNullOrWhiteSpace(InputAssemblies[0].ItemSpec)
+        )
+        {
+            Log.LogError("ILRepackLib: InputAssemblies must at least contain one item");
+            return false;
+        }
+
+        bool needTempOutputAssembly = InputAssemblies[0].ItemSpec == OutputFile.ItemSpec;
+        string outputAssembly = needTempOutputAssembly
+            ? Path.GetTempFileName()
+            : OutputFile.ItemSpec;
+
+        var cmdParams = new List<string>();
+
+        if (Parallel)
+            cmdParams.Add("/parallel");
+
+        if (!DebugInfo)
+            cmdParams.Add("/ndebug");
+
+        if (Verbose)
+            cmdParams.Add("/verbose");
+
+        if (Internalize)
+            cmdParams.Add("/internalize");
+
+        if (RenameInternalized)
+            cmdParams.Add("/renameinternalized");
+
+        if (Wildcards)
+            cmdParams.Add("/wildcards");
+
+        if (DelaySign)
+            cmdParams.Add("/delaysign");
+
+        if (ExcludeInternalizeSerializable)
+            cmdParams.Add("/excludeinternalizeserializable");
+
+        if (Union)
+            cmdParams.Add("/union");
+
+        if (AllowDup)
+            cmdParams.Add("/allowdup");
+
+        if (AllowDuplicateResources)
+            cmdParams.Add("/allowduplicateresources");
+
+        if (NoRepackRes)
+            cmdParams.Add("/noRepackRes");
+
+        if (CopyAttrs)
+            cmdParams.Add("/copyattrs");
+
+        if (AllowMultiple)
+            cmdParams.Add("/allowMultiple");
+
+        if (KeepOtherVersionReferences)
+            cmdParams.Add("/keepotherversionreferences");
+
+        if (PreserveTimestamp)
+            cmdParams.Add("/preservetimestamp");
+
+        if (SkipConfig)
+            cmdParams.Add("/skipconfig");
+
+        if (ILLink)
+            cmdParams.Add("/illink");
+
+        if (XmlDocs)
+            cmdParams.Add("/xmldocs");
+
+        if (ZeroPEKind)
+            cmdParams.Add("/zeropekind");
+
+        if (!string.IsNullOrWhiteSpace(TargetKind))
+            cmdParams.Add($"/target:{TargetKind}");
+
+        if (!string.IsNullOrWhiteSpace(Version))
+            cmdParams.Add($"/ver:{Version}");
+
+        if (LogFile is not null && !string.IsNullOrWhiteSpace(LogFile.ItemSpec))
+            cmdParams.Add($"/log:\"{LogFile.ItemSpec}\"");
+
+        if (KeyFile is not null && !string.IsNullOrWhiteSpace(KeyFile.ItemSpec))
+            cmdParams.Add($"/keyfile:\"{KeyFile.ItemSpec}\"");
+
+        if (KeyContainer is not null && !string.IsNullOrWhiteSpace(KeyContainer.ItemSpec))
+            cmdParams.Add($"/keycontainer:\"{KeyContainer.ItemSpec}\"");
+
+        if (ImportAttributeAssemblies is not null && ImportAttributeAssemblies.Length > 0)
+            cmdParams.AddRange(ImportAttributeAssemblies.Select(f => $"/attr:\"{f.ItemSpec}\""));
+
+        if (InternalizeAssemblies is not null && InternalizeAssemblies.Length > 0)
+            cmdParams.AddRange(
+                InternalizeAssemblies.Select(f => $"/internalizeassembly:\"{f.ItemSpec}\"")
+            );
+
+        if (RepackDropAttributes is not null && RepackDropAttributes.Length > 0)
+            cmdParams.AddRange(
+                RepackDropAttributes.Select(attr => $"/repackdrop:\"{attr.ItemSpec}\"")
+            );
+
+        if (AllowedDuplicateTypes is not null && AllowedDuplicateTypes.Length > 0)
+            cmdParams.AddRange(AllowedDuplicateTypes.Select(t => $"/allowdup:\"{t.ItemSpec}\""));
+
+        // TODO: handle
+        //InternalizeExclude
+
+        Log.LogMessage(
+            MessageImportance.High,
+            $"ILRepackLib: InputAssemblies (unfiltered): {string.Join("\n", InputAssemblies.Select(f => f.ItemSpec))}"
+        );
+        if (FilterAssemblies.Length > 0)
+        {
+            InputAssemblies = InputAssemblies
+                .Where(item =>
+                    FilterAssemblies.Any(x =>
+                        item.GetMetadata("Filename").ToLower().StartsWith(x.ItemSpec.ToLower())
+                        || Regex.IsMatch(
+                            item.GetMetadata("Filename"),
+                            x.ItemSpec,
+                            RegexOptions.IgnoreCase
+                        )
+                    )
+                )
+                .Distinct()
+                .ToArray();
+        }
+        Log.LogMessage(
+            MessageImportance.High,
+            $"ILRepackLib: InputAssemblies (filtered): {string.Join("\n", InputAssemblies.Distinct().Select(f => f.ItemSpec))}"
+        );
+
+        if (LibraryPaths is not null && LibraryPaths.Length > 0)
+            cmdParams.AddRange(
+                LibraryPaths.Select(item => item.ItemSpec).Select(l => $"/lib:\"{l}\"").Distinct()
+            );
+        else
+            cmdParams.AddRange(
+                InputAssemblies
+                    .Select(item => Path.GetDirectoryName(item.ItemSpec))
+                    .Select(l => $"/lib:\"{l}\"")
+                    .Distinct()
+            );
+
+        // must come last in this order
+        cmdParams.Add($"/out:\"{outputAssembly}\"");
+        cmdParams.AddRange(InputAssemblies.Select(item => $"\"{item.ItemSpec}\"").Distinct());
+
+        Log.LogMessage(
+            MessageImportance.High,
+            $"ILRepackLib: running `{string.Join(" ", cmdParams)}`"
+        );
+        RepackOptions repackOptions = new(cmdParams);
+        Log.LogMessage(MessageImportance.High, $"ILRepackLib: repackOptions {repackOptions}");
+
+        // create output dir
+        string outputPath = Path.GetDirectoryName(OutputFile.ItemSpec);
+        if (outputPath != null && !Directory.Exists(outputPath))
+        {
+            try
+            {
+                Directory.CreateDirectory(outputPath);
+            }
+            catch (Exception ex)
+            {
+                Log.LogErrorFromException(ex);
+                return false;
+            }
+        }
+
+        var stopWatch = new Stopwatch();
+        stopWatch.Start();
+
+        var repacker = new ILRepacking.ILRepack(repackOptions);
+        try
+        {
+            repacker.Repack();
+            Success = true;
+            Log.LogMessage(MessageImportance.High, $"ILRepackLib: success");
+        }
+        catch (Exception exception)
+        {
+            Log.LogMessage(MessageImportance.High, $"ILRepackLib: error: {exception.Message}");
+            Log.LogErrorFromException(exception, showStackTrace: true);
+            Success = false;
+        }
+
+        if (needTempOutputAssembly)
+        {
+            File.Copy(outputAssembly, OutputFile.ItemSpec, overwrite: true);
+            File.Delete(outputAssembly);
+        }
+
+        /*
+            System.Threading.Tasks.Task task = new(() => repacker.Repack());
+            {
+
+                    task.Start();
+                    task.Wait(Timeout);
+                    Success = true;
+                }
+                catch (Exception exception)
+                {
+                    Log.LogErrorFromException(exception);
+                    task.
+                    Success = false;
+                }
+            }
+            */
+
+        stopWatch.Stop();
+
+        Log.LogMessage(
+            MessageImportance.High,
+            $"ILRepackLib: {(Success ? "succeeded" : "failed")} in {stopWatch.ElapsedMilliseconds} ms"
+        );
+
+        return Success;
+    }
+
+    public virtual void Dispose() { }
+}

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <_ILRepackLibTaskAssemblyLocal>$(OutDir)ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyLocal>
+    <_ILRepackLibTaskAssemblyArtifact>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Lib.MSBuild.Task\$(Configuration)\ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyArtifact>
+    <_ILRepackLibTaskAssemblyPackage>$(MSBuildThisFileDirectory)..\lib\netstandard2.0\ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyPackage>
+
+    <_ILRepackLibTaskAssembly Condition="Exists('$(_ILRepackLibTaskAssemblyLocal)')">$(_ILRepackLibTaskAssemblyLocal)</_ILRepackLibTaskAssembly>
+    <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == ''">$(_ILRepackLibTaskAssemblyArtifact)</_ILRepackLibTaskAssembly>
+    <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == ''">$(_ILRepackLibTaskAssemblyPackage)</_ILRepackLibTaskAssembly>
+  </PropertyGroup>
+
+  <UsingTask
+    TaskName="ILRepack"
+    AssemblyFile="$(_ILRepackLibTaskAssembly)"
+  />
+
+  <PropertyGroup>
+    <_ILRepackConfigProps>$(ProjectDir)ILRepack.Config.props</_ILRepackConfigProps>
+    <_ILRepackTargets>$(ProjectDir)ILRepack.targets</_ILRepackTargets>
+  </PropertyGroup>
+
+  <Import Project="$(_ILRepackConfigProps)" Condition="'$(_ILRepackConfigProps)' != '' and Exists('$(_ILRepackConfigProps)')"/>
+  <Import Project="$(_ILRepackTargets)" Condition="'$(_ILRepackTargets)' != '' and Exists('$(_ILRepackTargets)')"/>
+</Project>

--- a/ILRepack.MSBuild.Task.sln
+++ b/ILRepack.MSBuild.Task.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Repack.Tool.Test", "Tests\R
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestLibA", "Tests\TestLibA\TestLibA.csproj", "{DB9A3118-59F2-47BA-B59C-6A0724FCC6A7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILRepack.Lib.MSBuild.Task", "ILRepack.Lib.MSBuild.Task\ILRepack.Lib.MSBuild.Task.csproj", "{2A6BF3E3-3C88-4DF8-B1A3-39ED111890B8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,10 @@ Global
 		{DB9A3118-59F2-47BA-B59C-6A0724FCC6A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DB9A3118-59F2-47BA-B59C-6A0724FCC6A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DB9A3118-59F2-47BA-B59C-6A0724FCC6A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A6BF3E3-3C88-4DF8-B1A3-39ED111890B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A6BF3E3-3C88-4DF8-B1A3-39ED111890B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A6BF3E3-3C88-4DF8-B1A3-39ED111890B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A6BF3E3-3C88-4DF8-B1A3-39ED111890B8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{4392BBE6-D1A9-4AD4-BD1D-26696B20184F} = {54749167-747B-4C31-94CC-AD76608E23F7}


### PR DESCRIPTION
- **feat: add ILRepack.Lib.MSBuild.Task project**
- **build: add package reference to ILRepack v2.0.44**
- **build: set up targets for ILRepack task using ILRepack.Tool.MSBuild.Task**
- **feat: implement ILRepack task in ILRepackLib.cs**
- **feat: implement KageKirin.ILRepack.Lib.MSBuild.Task.targets**
- **refactor: set RepackOptions directly instead of creating and parsing command line**
- **refactor: check input assemblies for existence**
- **refactor: use local target file instead of temp file**
- **refactor: simplify object initialization**
