### PR TITLE
build: remove incompatible build properties from ILRepack.Lib.MSBuild.Task

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
@@ -11,7 +11,6 @@
     <IsPublishable>true</IsPublishable>
     <PackRelease>true</PackRelease>
     <PublishRelease>true</PublishRelease>
-    <SelfContained>true</SelfContained>
     <DebugType>embedded</DebugType>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>


### PR DESCRIPTION
- **build: remove trailing backslash for PackagePath**
- **build: remove PublishSingleFile flag**
- **build: remove SelfContained flag**
