### PR TITLE
fix: use correct task assembly paths in targets files

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -7,11 +7,23 @@
     <_ILRepackLibTaskAssemblyArtifact>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Lib.MSBuild.Task\$(Configuration)\ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyArtifact>
     <_ILRepackLibTaskAssemblyArtifactLowerCase>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Lib.MSBuild.Task\$(Configuration.ToLowerInvariant())\ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyArtifactLowerCase>
 
-    <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == '' and Exists('$(_ILRepackLibTaskAssemblyLocal)')">$(_ILRepackLibTaskAssemblyLocal)</_ILRepackLibTaskAssembly>
-    <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == '' and Exists('$(_ILRepackLibTaskAssemblyPackage)')">$(_ILRepackLibTaskAssemblyPackage)</_ILRepackLibTaskAssembly>
-    <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == '' and Exists('$(_ILRepackLibTaskAssemblyArtifact)')">$(_ILRepackLibTaskAssemblyArtifact)</_ILRepackLibTaskAssembly>
-    <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == '' and Exists('$(_ILRepackLibTaskAssemblyArtifactLowerCase)')">$(_ILRepackLibTaskAssemblyArtifactLowerCase)</_ILRepackLibTaskAssembly>
+    <_ILRepackLibTaskAssembly>$(_ILRepackLibTaskAssemblyArtifactLowerCase)</_ILRepackLibTaskAssembly>
+    <_ILRepackLibTaskAssembly Condition="!Exists('$(_ILRepackLibTaskAssembly)')">$(_ILRepackLibTaskAssemblyLocal)</_ILRepackLibTaskAssembly>
+    <_ILRepackLibTaskAssembly Condition="!Exists('$(_ILRepackLibTaskAssembly)')">$(_ILRepackLibTaskAssemblyPackage)</_ILRepackLibTaskAssembly>
+    <_ILRepackLibTaskAssembly Condition="!Exists('$(_ILRepackLibTaskAssembly)')">$(_ILRepackLibTaskAssemblyArtifact)</_ILRepackLibTaskAssembly>
+    <_ILRepackLibTaskAssembly Condition="!Exists('$(_ILRepackLibTaskAssembly)')">$(_ILRepackLibTaskAssemblyArtifactLowerCase)</_ILRepackLibTaskAssembly>
   </PropertyGroup>
+
+  <Target Name="ILRepackLibInfo" BeforeTargets="Compile">
+    <Message Text="_ILRepackLibTaskAssemblyLocal: $(_ILRepackLibTaskAssemblyLocal)" Importance="high" />
+    <Message Text="_ILRepackLibTaskAssemblyLocal: $(_ILRepackLibTaskAssemblyLocal) exists" Condition="Exists('$(_ILRepackLibTaskAssemblyLocal)')" Importance="high" />
+    <Message Text="_ILRepackLibTaskAssemblyPackage: $(_ILRepackLibTaskAssemblyPackage)" Importance="high" />
+    <Message Text="_ILRepackLibTaskAssemblyPackage: $(_ILRepackLibTaskAssemblyPackage) exists" Condition="Exists('$(_ILRepackLibTaskAssemblyPackage)')" Importance="high" />
+    <Message Text="_ILRepackLibTaskAssemblyArtifact: $(_ILRepackLibTaskAssemblyArtifact)" Importance="high" />
+    <Message Text="_ILRepackLibTaskAssemblyArtifact: $(_ILRepackLibTaskAssemblyArtifact) exists" Condition="Exists('$(_ILRepackLibTaskAssemblyArtifact)')" Importance="high" />
+    <Message Text="_ILRepackLibTaskAssemblyArtifactLowerCase: $(_ILRepackLibTaskAssemblyArtifactLowerCase)" Importance="high" />
+    <Message Text="_ILRepackLibTaskAssemblyArtifactLowerCase: $(_ILRepackLibTaskAssemblyArtifactLowerCase) exists" Condition="Exists('$(_ILRepackLibTaskAssemblyArtifactLowerCase)')" Importance="high" />
+  </Target>
 
   <UsingTask
     TaskName="ILRepack"

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -3,14 +3,14 @@
 
   <PropertyGroup>
     <_ILRepackLibTaskAssemblyLocal>$(OutDir)ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyLocal>
-    <_ILRepackLibTaskAssemblyArtifact>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Lib.MSBuild.Task\$(Configuration)\ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyArtifact>
-    <_ILRepackLibTaskAssemblyArtifactLowerCase>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Lib.MSBuild.Task\$(Configuration)\ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyArtifactLowerCase>
     <_ILRepackLibTaskAssemblyPackage>$(MSBuildThisFileDirectory)..\lib\netstandard2.0\ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyPackage>
+    <_ILRepackLibTaskAssemblyArtifact>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Lib.MSBuild.Task\$(Configuration)\ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyArtifact>
+    <_ILRepackLibTaskAssemblyArtifactLowerCase>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Lib.MSBuild.Task\$(Configuration.ToLowerInvariant())\ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyArtifactLowerCase>
 
     <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == '' and Exists('$(_ILRepackLibTaskAssemblyLocal)')">$(_ILRepackLibTaskAssemblyLocal)</_ILRepackLibTaskAssembly>
+    <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == '' and Exists('$(_ILRepackLibTaskAssemblyPackage)')">$(_ILRepackLibTaskAssemblyPackage)</_ILRepackLibTaskAssembly>
     <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == '' and Exists('$(_ILRepackLibTaskAssemblyArtifact)')">$(_ILRepackLibTaskAssemblyArtifact)</_ILRepackLibTaskAssembly>
     <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == '' and Exists('$(_ILRepackLibTaskAssemblyArtifactLowerCase)')">$(_ILRepackLibTaskAssemblyArtifactLowerCase)</_ILRepackLibTaskAssembly>
-    <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == '' and Exists('$(_ILRepackLibTaskAssemblyPackage)')">$(_ILRepackLibTaskAssemblyPackage)</_ILRepackLibTaskAssembly>
   </PropertyGroup>
 
   <UsingTask

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -7,7 +7,7 @@
     <_ILRepackLibTaskAssemblyPackage>$(MSBuildThisFileDirectory)..\lib\netstandard2.0\ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyPackage>
 
     <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == '' and Exists('$(_ILRepackLibTaskAssemblyLocal)')">$(_ILRepackLibTaskAssemblyLocal)</_ILRepackLibTaskAssembly>
-    <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == ''">$(_ILRepackLibTaskAssemblyArtifact)</_ILRepackLibTaskAssembly>
+    <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == '' and Exists('$(_ILRepackLibTaskAssemblyArtifact)')">$(_ILRepackLibTaskAssemblyArtifact)</_ILRepackLibTaskAssembly>
     <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == ''">$(_ILRepackLibTaskAssemblyPackage)</_ILRepackLibTaskAssembly>
   </PropertyGroup>
 

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -8,7 +8,7 @@
 
     <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == '' and Exists('$(_ILRepackLibTaskAssemblyLocal)')">$(_ILRepackLibTaskAssemblyLocal)</_ILRepackLibTaskAssembly>
     <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == '' and Exists('$(_ILRepackLibTaskAssemblyArtifact)')">$(_ILRepackLibTaskAssemblyArtifact)</_ILRepackLibTaskAssembly>
-    <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == ''">$(_ILRepackLibTaskAssemblyPackage)</_ILRepackLibTaskAssembly>
+    <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == '' and Exists('$(_ILRepackLibTaskAssemblyPackage)')">$(_ILRepackLibTaskAssemblyPackage)</_ILRepackLibTaskAssembly>
   </PropertyGroup>
 
   <UsingTask

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -4,10 +4,12 @@
   <PropertyGroup>
     <_ILRepackLibTaskAssemblyLocal>$(OutDir)ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyLocal>
     <_ILRepackLibTaskAssemblyArtifact>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Lib.MSBuild.Task\$(Configuration)\ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyArtifact>
+    <_ILRepackLibTaskAssemblyArtifactLowerCase>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Lib.MSBuild.Task\$(Configuration)\ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyArtifactLowerCase>
     <_ILRepackLibTaskAssemblyPackage>$(MSBuildThisFileDirectory)..\lib\netstandard2.0\ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyPackage>
 
     <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == '' and Exists('$(_ILRepackLibTaskAssemblyLocal)')">$(_ILRepackLibTaskAssemblyLocal)</_ILRepackLibTaskAssembly>
     <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == '' and Exists('$(_ILRepackLibTaskAssemblyArtifact)')">$(_ILRepackLibTaskAssemblyArtifact)</_ILRepackLibTaskAssembly>
+    <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == '' and Exists('$(_ILRepackLibTaskAssemblyArtifactLowerCase)')">$(_ILRepackLibTaskAssemblyArtifactLowerCase)</_ILRepackLibTaskAssembly>
     <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == '' and Exists('$(_ILRepackLibTaskAssemblyPackage)')">$(_ILRepackLibTaskAssemblyPackage)</_ILRepackLibTaskAssembly>
   </PropertyGroup>
 

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -6,7 +6,7 @@
     <_ILRepackLibTaskAssemblyArtifact>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Lib.MSBuild.Task\$(Configuration)\ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyArtifact>
     <_ILRepackLibTaskAssemblyPackage>$(MSBuildThisFileDirectory)..\lib\netstandard2.0\ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyPackage>
 
-    <_ILRepackLibTaskAssembly Condition="Exists('$(_ILRepackLibTaskAssemblyLocal)')">$(_ILRepackLibTaskAssemblyLocal)</_ILRepackLibTaskAssembly>
+    <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == '' and Exists('$(_ILRepackLibTaskAssemblyLocal)')">$(_ILRepackLibTaskAssemblyLocal)</_ILRepackLibTaskAssembly>
     <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == ''">$(_ILRepackLibTaskAssemblyArtifact)</_ILRepackLibTaskAssembly>
     <_ILRepackLibTaskAssembly Condition="'$(_ILRepackLibTaskAssembly)' == ''">$(_ILRepackLibTaskAssemblyPackage)</_ILRepackLibTaskAssembly>
   </PropertyGroup>

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -8,7 +8,7 @@
 
     <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == '' and Exists('$(_ILRepackToolTaskAssemblyLocal)')">$(_ILRepackToolTaskAssemblyLocal)</_ILRepackToolTaskAssembly>
     <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == '' and Exists('$(_ILRepackToolTaskAssemblyArtifact)')">$(_ILRepackToolTaskAssemblyArtifact)</_ILRepackToolTaskAssembly>
-    <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == ''">$(_ILRepackToolTaskAssemblyPackage)</_ILRepackToolTaskAssembly>
+    <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == '' and Exists('$(_ILRepackToolTaskAssemblyPackage)')">$(_ILRepackToolTaskAssemblyPackage)</_ILRepackToolTaskAssembly>
   </PropertyGroup>
 
   <UsingTask

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -7,7 +7,7 @@
     <_ILRepackToolTaskAssemblyPackage>$(MSBuildThisFileDirectory)..\lib\netstandard2.0\ILRepack.Tool.MSBuild.Task.dll</_ILRepackToolTaskAssemblyPackage>
 
     <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == '' and Exists('$(_ILRepackToolTaskAssemblyLocal)')">$(_ILRepackToolTaskAssemblyLocal)</_ILRepackToolTaskAssembly>
-    <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == ''">$(_ILRepackToolTaskAssemblyArtifact)</_ILRepackToolTaskAssembly>
+    <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == '' and Exists('$(_ILRepackToolTaskAssemblyArtifact)')">$(_ILRepackToolTaskAssemblyArtifact)</_ILRepackToolTaskAssembly>
     <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == ''">$(_ILRepackToolTaskAssemblyPackage)</_ILRepackToolTaskAssembly>
   </PropertyGroup>
 

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -4,10 +4,12 @@
   <PropertyGroup>
     <_ILRepackToolTaskAssemblyLocal>$(OutDir)ILRepack.Tool.MSBuild.Task.dll</_ILRepackToolTaskAssemblyLocal>
     <_ILRepackToolTaskAssemblyArtifact>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Tool.MSBuild.Task\$(Configuration)\ILRepack.Tool.MSBuild.Task.dll</_ILRepackToolTaskAssemblyArtifact>
+    <_ILRepackToolTaskAssemblyArtifactLowerCase>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Tool.MSBuild.Task\$(Configuration.ToLowerInvariant())\ILRepack.Tool.MSBuild.Task.dll</_ILRepackToolTaskAssemblyArtifactLowerCase>
     <_ILRepackToolTaskAssemblyPackage>$(MSBuildThisFileDirectory)..\lib\netstandard2.0\ILRepack.Tool.MSBuild.Task.dll</_ILRepackToolTaskAssemblyPackage>
 
     <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == '' and Exists('$(_ILRepackToolTaskAssemblyLocal)')">$(_ILRepackToolTaskAssemblyLocal)</_ILRepackToolTaskAssembly>
     <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == '' and Exists('$(_ILRepackToolTaskAssemblyArtifact)')">$(_ILRepackToolTaskAssemblyArtifact)</_ILRepackToolTaskAssembly>
+    <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == '' and Exists('$(_ILRepackToolTaskAssemblyArtifactLowerCase)')">$(_ILRepackToolTaskAssemblyArtifactLowerCase)</_ILRepackToolTaskAssembly>
     <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == '' and Exists('$(_ILRepackToolTaskAssemblyPackage)')">$(_ILRepackToolTaskAssemblyPackage)</_ILRepackToolTaskAssembly>
   </PropertyGroup>
 

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -7,11 +7,23 @@
     <_ILRepackToolTaskAssemblyArtifact>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Tool.MSBuild.Task\$(Configuration)\ILRepack.Tool.MSBuild.Task.dll</_ILRepackToolTaskAssemblyArtifact>
     <_ILRepackToolTaskAssemblyArtifactLowerCase>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Tool.MSBuild.Task\$(Configuration.ToLowerInvariant())\ILRepack.Tool.MSBuild.Task.dll</_ILRepackToolTaskAssemblyArtifactLowerCase>
 
-    <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == '' and Exists('$(_ILRepackToolTaskAssemblyLocal)')">$(_ILRepackToolTaskAssemblyLocal)</_ILRepackToolTaskAssembly>
-    <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == '' and Exists('$(_ILRepackToolTaskAssemblyPackage)')">$(_ILRepackToolTaskAssemblyPackage)</_ILRepackToolTaskAssembly>
-    <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == '' and Exists('$(_ILRepackToolTaskAssemblyArtifact)')">$(_ILRepackToolTaskAssemblyArtifact)</_ILRepackToolTaskAssembly>
-    <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == '' and Exists('$(_ILRepackToolTaskAssemblyArtifactLowerCase)')">$(_ILRepackToolTaskAssemblyArtifactLowerCase)</_ILRepackToolTaskAssembly>
+    <_ILRepackToolTaskAssembly>$(_ILRepackToolTaskAssemblyArtifactLowerCase)</_ILRepackToolTaskAssembly>
+    <_ILRepackToolTaskAssembly Condition="!Exists('$(_ILRepackToolTaskAssembly)')">$(_ILRepackToolTaskAssemblyLocal)</_ILRepackToolTaskAssembly>
+    <_ILRepackToolTaskAssembly Condition="!Exists('$(_ILRepackToolTaskAssembly)')">$(_ILRepackToolTaskAssemblyPackage)</_ILRepackToolTaskAssembly>
+    <_ILRepackToolTaskAssembly Condition="!Exists('$(_ILRepackToolTaskAssembly)')">$(_ILRepackToolTaskAssemblyArtifact)</_ILRepackToolTaskAssembly>
+    <_ILRepackToolTaskAssembly Condition="!Exists('$(_ILRepackToolTaskAssembly)')">$(_ILRepackToolTaskAssemblyArtifactLowerCase)</_ILRepackToolTaskAssembly>
   </PropertyGroup>
+
+  <Target Name="ILRepackToolInfo" BeforeTargets="Compile">
+    <Message Text="_ILRepackToolTaskAssemblyLocal: $(_ILRepackToolTaskAssemblyLocal)" Importance="high" />
+    <Message Text="_ILRepackToolTaskAssemblyLocal: $(_ILRepackToolTaskAssemblyLocal) exists" Condition="Exists('$(_ILRepackToolTaskAssemblyLocal)')" Importance="high" />
+    <Message Text="_ILRepackToolTaskAssemblyPackage: $(_ILRepackToolTaskAssemblyPackage)" Importance="high" />
+    <Message Text="_ILRepackToolTaskAssemblyPackage: $(_ILRepackToolTaskAssemblyPackage) exists" Condition="Exists('$(_ILRepackToolTaskAssemblyPackage)')" Importance="high" />
+    <Message Text="_ILRepackToolTaskAssemblyArtifact: $(_ILRepackToolTaskAssemblyArtifact)" Importance="high" />
+    <Message Text="_ILRepackToolTaskAssemblyArtifact: $(_ILRepackToolTaskAssemblyArtifact) exists" Condition="Exists('$(_ILRepackToolTaskAssemblyArtifact)')" Importance="high" />
+    <Message Text="_ILRepackToolTaskAssemblyArtifactLowerCase: $(_ILRepackToolTaskAssemblyArtifactLowerCase)" Importance="high" />
+    <Message Text="_ILRepackToolTaskAssemblyArtifactLowerCase: $(_ILRepackToolTaskAssemblyArtifactLowerCase) exists" Condition="Exists('$(_ILRepackToolTaskAssemblyArtifactLowerCase)')" Importance="high" />
+  </Target>
 
   <UsingTask
     TaskName="ILRepack"

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -6,7 +6,7 @@
     <_ILRepackToolTaskAssemblyArtifact>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Tool.MSBuild.Task\$(Configuration)\ILRepack.Tool.MSBuild.Task.dll</_ILRepackToolTaskAssemblyArtifact>
     <_ILRepackToolTaskAssemblyPackage>$(MSBuildThisFileDirectory)..\lib\netstandard2.0\ILRepack.Tool.MSBuild.Task.dll</_ILRepackToolTaskAssemblyPackage>
 
-    <_ILRepackToolTaskAssembly Condition="Exists('$(_ILRepackToolTaskAssemblyLocal)')">$(_ILRepackToolTaskAssemblyLocal)</_ILRepackToolTaskAssembly>
+    <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == '' and Exists('$(_ILRepackToolTaskAssemblyLocal)')">$(_ILRepackToolTaskAssemblyLocal)</_ILRepackToolTaskAssembly>
     <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == ''">$(_ILRepackToolTaskAssemblyArtifact)</_ILRepackToolTaskAssembly>
     <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == ''">$(_ILRepackToolTaskAssemblyPackage)</_ILRepackToolTaskAssembly>
   </PropertyGroup>

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -3,14 +3,14 @@
 
   <PropertyGroup>
     <_ILRepackToolTaskAssemblyLocal>$(OutDir)ILRepack.Tool.MSBuild.Task.dll</_ILRepackToolTaskAssemblyLocal>
+    <_ILRepackToolTaskAssemblyPackage>$(MSBuildThisFileDirectory)..\lib\netstandard2.0\ILRepack.Tool.MSBuild.Task.dll</_ILRepackToolTaskAssemblyPackage>
     <_ILRepackToolTaskAssemblyArtifact>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Tool.MSBuild.Task\$(Configuration)\ILRepack.Tool.MSBuild.Task.dll</_ILRepackToolTaskAssemblyArtifact>
     <_ILRepackToolTaskAssemblyArtifactLowerCase>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Tool.MSBuild.Task\$(Configuration.ToLowerInvariant())\ILRepack.Tool.MSBuild.Task.dll</_ILRepackToolTaskAssemblyArtifactLowerCase>
-    <_ILRepackToolTaskAssemblyPackage>$(MSBuildThisFileDirectory)..\lib\netstandard2.0\ILRepack.Tool.MSBuild.Task.dll</_ILRepackToolTaskAssemblyPackage>
 
     <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == '' and Exists('$(_ILRepackToolTaskAssemblyLocal)')">$(_ILRepackToolTaskAssemblyLocal)</_ILRepackToolTaskAssembly>
+    <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == '' and Exists('$(_ILRepackToolTaskAssemblyPackage)')">$(_ILRepackToolTaskAssemblyPackage)</_ILRepackToolTaskAssembly>
     <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == '' and Exists('$(_ILRepackToolTaskAssemblyArtifact)')">$(_ILRepackToolTaskAssemblyArtifact)</_ILRepackToolTaskAssembly>
     <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == '' and Exists('$(_ILRepackToolTaskAssemblyArtifactLowerCase)')">$(_ILRepackToolTaskAssemblyArtifactLowerCase)</_ILRepackToolTaskAssembly>
-    <_ILRepackToolTaskAssembly Condition="'$(_ILRepackToolTaskAssembly)' == '' and Exists('$(_ILRepackToolTaskAssemblyPackage)')">$(_ILRepackToolTaskAssemblyPackage)</_ILRepackToolTaskAssembly>
   </PropertyGroup>
 
   <UsingTask


### PR DESCRIPTION
in `KageKirin.ILRepack.Tool.MSBuild.Task.targets`:

- **fix: add missing condition for using `$(_ILRepackToolTaskAssemblyLocal)` as value for `$(_ILRepackToolTaskAssembly)`**
- **fix: add missing condition for using `$(_ILRepackToolTaskAssemblyArtifact)` as value for `$(_ILRepackToolTaskAssembly)`**
- **fix: add missing condition for using `$(_ILRepackToolTaskAssemblyPackage)` as value for `$(_ILRepackToolTaskAssembly)`**
- **feat: add lower case variant for `$(_ILRepackToolTaskAssemblyArtifact)` as value for `$(_ILRepackToolTaskAssembly)`**
- **refactor: change order of value alternatives for `$(_ILRepackToolTaskAssembly)`**


in `KageKirin.ILRepack.Lib.MSBuild.Task.targets`:

- **fix: add missing condition for using `$(_ILRepackLibTaskAssemblyLocal)` as value for `$(_ILRepackLibTaskAssembly)`**
- **fix: add missing condition for using `$(_ILRepackLibTaskAssemblyArtifact)` as value for `$(_ILRepackLibTaskAssembly)`**
- **fix: add missing condition for using `$(_ILRepackLibTaskAssemblyPackage)` as value for `$(_ILRepackLibTaskAssembly)`**
- **feat: add lower case variant for `$(_ILRepackLibTaskAssemblyArtifact)` as value for `$(_ILRepackLibTaskAssembly)`**
- **refactor: change order of value alternatives for `$(_ILRepackLibTaskAssembly)`**
