### PR TITLE
build: remove build-order dependency between the task projects

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
@@ -12,7 +12,6 @@
     <PackRelease>true</PackRelease>
     <PublishRelease>true</PublishRelease>
     <DebugType>embedded</DebugType>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Label="build metadata">

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
@@ -41,13 +41,7 @@
     <PackageReference Include="ILRepack.Lib" PrivateAssets="all" IncludeAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ILRepack.Tool.MSBuild.Task\ILRepack.Tool.MSBuild.Task.csproj" PrivateAssets="all" IncludeAssets="all" />
-  </ItemGroup>
-
-  <Import Project="..\ILRepack.Tool.MSBuild.Task\build\KageKirin.ILRepack.Tool.MSBuild.Task.targets" />
   <Import Project="ILRepack.targets" />
-
 
   <Target Name="INFO" BeforeTargets="Compile">
     <Message Text="PkgILRepack $(PkgILRepack)" Importance="high" />

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.not
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.not
@@ -1,0 +1,4 @@
+Microsoft.Win32
+System
+System.IO
+Microsoft.Build

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.targets
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.targets
@@ -1,44 +1,19 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <Target Name="ILRepacker" AfterTargets="Compile" DependsOnTargets="ResolveAssemblyReferences">
+  <Target Name="ILRepackerExe" AfterTargets="Compile" DependsOnTargets="ResolveAssemblyReferences">
 
     <Message Text="Repacking $(IntermediateOutputPath)" Importance="high" />
+    <PropertyGroup>
+      <_ThisAssembly>$(IntermediateOutputPath)$(TargetFileName)</_ThisAssembly>
+      <_ILRepackAssembly>$(PkgILRepack_Lib)/lib/net472/ILRepack.dll</_ILRepackAssembly>
+      <_ILRepackExclude>ILRepack.not</_ILRepackExclude>
+      <_ILRepackExe>$(PkgILRepack)/tools/ILRepack.exe</_ILRepackExe>
+      <_ILRepackCmd>$(_ILRepackExe) /internalize:$(_ILRepackExclude) /renameinternalized /log:$(_ThisAssembly).ilrepack.log /out:$(_ThisAssembly).repack $(_ThisAssembly) $(_ILRepackAssembly)</_ILRepackCmd>
+    </PropertyGroup>
 
-    <ItemGroup>
-      <MainAssembly Include="$(IntermediateOutputPath)$(TargetFileName)" />
-
-      <InputAssemblies Include="@(ReferenceCopyLocalPaths)" />
-      <InputAssemblies Include="$(PkgILRepack_Lib)\**\*.dll" />
-
-      <FilterAssemblies Include="$(AssemblyName)" />
-      <FilterAssemblies Include="ILRepack.dll" />
-      <FilterAssemblies Include="ILRepack$" />
-
-      <LibraryPath Include="%(InputAssemblies.Directory)" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <DoNotInternalizeAssemblies Include="@(MainAssembly)" />
-    </ItemGroup>
-
-    <Message Text="Repacking assemblies in $(IntermediateOutputPath): @(InputAssemblies->'%(Identity)', ' ') into @(MainAssembly->'%(Identity)')" Importance="high" />
-
-    <ILRepack
-      Parallel="false"
-      DebugInfo="true"
-      Verbose="true"
-      Internalize="true"
-      RenameInternalized="false"
-      InputAssemblies="@(MainAssembly);@(InputAssemblies)"
-      InternalizeExclude="@(DoNotInternalizeAssemblies)"
-      FilterAssemblies="@(FilterAssemblies)"
-
-      OutputFile="@(MainAssembly)"
-      LogFile="$(OutputPath)$(AssemblyName).ilrepack.log"
-    />
+    <Message Text="running: $(_ILRepackCmd)" Importance="high" />
+    <Exec Command="dotnet $(_ILRepackCmd)" />
+    <Move SourceFiles="$(_ThisAssembly).repack" DestinationFiles="$(_ThisAssembly)" />
 
   </Target>
-
-
 </Project>

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <_ILRepackLibTaskAssemblyLocal>$(OutDir)ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyLocal>
-    <_ILRepackLibTaskAssemblyArtifact>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Lib.MSBuild.Task\$(Configuration)\ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyArtifact>
+    <_ILRepackLibTaskAssemblyArtifact>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Lib.MSBuild.Task\$(Configuration.ToLowerInvariant())\ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyArtifact>
     <_ILRepackLibTaskAssemblyPackage>$(MSBuildThisFileDirectory)..\lib\netstandard2.0\ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyPackage>
 
     <_ILRepackLibTaskAssembly Condition="Exists('$(_ILRepackLibTaskAssemblyLocal)')">$(_ILRepackLibTaskAssemblyLocal)</_ILRepackLibTaskAssembly>

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <_ILRepackToolTaskAssemblyLocal>$(OutDir)ILRepack.Tool.MSBuild.Task.dll</_ILRepackToolTaskAssemblyLocal>
-    <_ILRepackToolTaskAssemblyArtifact>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Tool.MSBuild.Task\$(Configuration)\ILRepack.Tool.MSBuild.Task.dll</_ILRepackToolTaskAssemblyArtifact>
+    <_ILRepackToolTaskAssemblyArtifact>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Tool.MSBuild.Task\$(Configuration.ToLowerInvariant())\ILRepack.Tool.MSBuild.Task.dll</_ILRepackToolTaskAssemblyArtifact>
     <_ILRepackToolTaskAssemblyPackage>$(MSBuildThisFileDirectory)..\lib\netstandard2.0\ILRepack.Tool.MSBuild.Task.dll</_ILRepackToolTaskAssemblyPackage>
 
     <_ILRepackToolTaskAssembly Condition="Exists('$(_ILRepackToolTaskAssemblyLocal)')">$(_ILRepackToolTaskAssemblyLocal)</_ILRepackToolTaskAssembly>


### PR DESCRIPTION
- **build: remove dependency on ILRepack.Tool.MSBuild.Task**
- **build: refactor ILRepack.targets to minimal but independent call to ILRepack**
- **build: remove flag CopyLocalLockFileAssemblies**
