### PR TITLE
build(ILRepack.Lib.MSBuild.Task): remove project order-only reference to ILRepack.Tool.MSBuild.Task

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
@@ -40,15 +40,6 @@
     <PackageReference Include="ILRepack.Lib" PrivateAssets="all" IncludeAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ILRepack.Tool.MSBuild.Task\ILRepack.Tool.MSBuild.Task.csproj">
-      <Project>{F7641765-9A21-43AF-B577-46E54E945320}</Project>
-      <Name>ILRepack.Tool.MSBuild.Task</Name>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-    </ProjectReference>
-  </ItemGroup>
-
-  <Import Project="..\ILRepack.Tool.MSBuild.Task\build\KageKirin.ILRepack.Tool.MSBuild.Task.targets" />
   <Import Project="ILRepack.targets" />
 
   <Target Name="INFO" BeforeTargets="Compile">


### PR DESCRIPTION
This reverts commit 5c00aca08b72a162795e3b6a002823916b638086.

reason: no dependency between the projects.
