### PR TITLE
build: implement tasks to retrieve assembly in potential output folders

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -15,7 +15,41 @@
     <_ILRepackLibTaskAssembly Condition="!Exists('$(_ILRepackLibTaskAssembly)')">$(_ILRepackLibTaskAssemblyPackage)</_ILRepackLibTaskAssembly>
     <_ILRepackLibTaskAssembly Condition="!Exists('$(_ILRepackLibTaskAssembly)')">$(_ILRepackLibTaskAssemblyArtifact)</_ILRepackLibTaskAssembly>
     <_ILRepackLibTaskAssembly Condition="!Exists('$(_ILRepackLibTaskAssembly)')">$(_ILRepackLibTaskAssemblyArtifactLowerCase)</_ILRepackLibTaskAssembly>
+
+    <_MsBuildAssembly>$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll</_MsBuildAssembly>
+    <_MsBuildTaskFactory>CodeTaskFactory</_MsBuildTaskFactory>
+    <_MsBuildTaskFactory Condition=" '$(MSBuildVersion.Substring(0,2))' >= 16 Or ('$(MSBuildVersion.Substring(0,2))' == 15 And '$(MSBuildVersion.Substring(3,1))' >= 8)">RoslynCodeTaskFactory</_MsBuildTaskFactory>
+
   </PropertyGroup>
+
+  <UsingTask
+    TaskName="LocateLibFile"
+    TaskFactory="$(_MsBuildTaskFactory)"
+    AssemblyFile="$(_MsBuildAssembly)">
+    <ParameterGroup>
+      <RootDir ParameterType="System.String" Required="true" />
+      <FileName ParameterType="System.String" Required="true" />
+      <Files ParameterType="System.String[]" Required="false" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System" />
+      <Using Namespace="System.Diagnostics" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Linq" />
+      <Using Namespace="System.Collections.Generic" />
+      <Using Namespace="System.Text.RegularExpressions" />
+      <Code Type="Fragment" Language="cs">
+      <![CDATA[
+        Log.LogMessage(MessageImportance.High, $"LocateLibFile: looking for {FileName} in {RootDir} and below");
+        Files = Directory.EnumerateFiles(RootDir, FileName, SearchOption.AllDirectories).ToArray();
+        foreach(var file in Files)
+        {
+          Log.LogMessage(MessageImportance.High, $"LocateLibFile[{FileName}]: found {file}");
+        }
+      ]]>
+      </Code>
+    </Task>
+  </UsingTask>
 
   <Target Name="ILRepackLibInfo" BeforeTargets="Compile">
     <Message Text="_ILRepackLibTaskAssemblyLocal: $(_ILRepackLibTaskAssemblyLocal)" Importance="high" />

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -63,6 +63,48 @@
 
     <Message Text="_ILRepackLibTaskAssembly: $(_ILRepackLibTaskAssembly)" Importance="high" />
     <Message Text="_ILRepackLibTaskAssembly: $(_ILRepackLibTaskAssembly) exists" Condition="Exists('$(_ILRepackLibTaskAssembly)')" Importance="high" />
+
+    <LocateLibFile
+      RootDir="."
+      FileName="$(_ILRepackLibTaskAssemblyFile)">
+      <Output
+        TaskParameter="Files"
+        ItemName="_ILRepackLibAssemblyFiles"
+      />
+    </LocateLibFile>
+    <Message Text="_ILRepackLibAssemblyFiles: @(_ILRepackLibAssemblyFiles)" Importance="high" />
+
+    <LocateLibFile
+      RootDir="$(OutDir)"
+      FileName="$(_ILRepackLibTaskAssemblyFile)">
+      <Output
+        TaskParameter="Files"
+        ItemName="_ILRepackLibAssemblyFiles"
+      />
+    </LocateLibFile>
+    <Message Text="_ILRepackLibAssemblyFiles: @(_ILRepackLibAssemblyFiles)" Importance="high" />
+
+    <LocateLibFile
+      RootDir="$(MSBuildThisFileDirectory)"
+      FileName="$(_ILRepackLibTaskAssemblyFile)">
+      <Output
+        TaskParameter="Files"
+        ItemName="_ILRepackLibAssemblyFiles"
+      />
+    </LocateLibFile>
+    <Message Text="_ILRepackLibAssemblyFiles: @(_ILRepackLibAssemblyFiles)" Importance="high" />
+
+    <LocateLibFile
+      RootDir="$(MSBuildThisFileDirectory)..\.."
+      FileName="$(_ILRepackLibTaskAssemblyFile)">
+      <Output
+        TaskParameter="Files"
+        ItemName="_ILRepackLibAssemblyFiles"
+      />
+    </LocateLibFile>
+    <Message Text="_ILRepackLibAssemblyFiles: @(_ILRepackLibAssemblyFiles)" Importance="high" />
+
+
   </Target>
 
   <UsingTask

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -64,6 +64,47 @@
 
     <Message Text="_ILRepackToolTaskAssembly: $(_ILRepackToolTaskAssembly)" Importance="high" />
     <Message Text="_ILRepackToolTaskAssembly: $(_ILRepackToolTaskAssembly) exists" Condition="Exists('$(_ILRepackToolTaskAssembly)')" Importance="high" />
+
+    <LocateToolFile
+      RootDir="."
+      FileName="$(_ILRepackToolTaskAssemblyFile)">
+      <Output
+        TaskParameter="Files"
+        ItemName="_ILRepackToolAssemblyFiles"
+      />
+    </LocateToolFile>
+    <Message Text="_ILRepackToolAssemblyFiles: @(_ILRepackToolAssemblyFiles)" Importance="high" />
+
+    <LocateToolFile
+      RootDir="$(OutDir)"
+      FileName="$(_ILRepackToolTaskAssemblyFile)">
+      <Output
+        TaskParameter="Files"
+        ItemName="_ILRepackToolAssemblyFiles"
+      />
+    </LocateToolFile>
+    <Message Text="_ILRepackToolAssemblyFiles: @(_ILRepackToolAssemblyFiles)" Importance="high" />
+
+    <LocateToolFile
+      RootDir="$(MSBuildThisFileDirectory)"
+      FileName="$(_ILRepackToolTaskAssemblyFile)">
+      <Output
+        TaskParameter="Files"
+        ItemName="_ILRepackToolAssemblyFiles"
+      />
+    </LocateToolFile>
+    <Message Text="_ILRepackToolAssemblyFiles: @(_ILRepackToolAssemblyFiles)" Importance="high" />
+
+    <LocateToolFile
+      RootDir="$(MSBuildThisFileDirectory)..\.."
+      FileName="$(_ILRepackToolTaskAssemblyFile)">
+      <Output
+        TaskParameter="Files"
+        ItemName="_ILRepackToolAssemblyFiles"
+      />
+    </LocateToolFile>
+    <Message Text="_ILRepackToolAssemblyFiles: @(_ILRepackToolAssemblyFiles)" Importance="high" />
+
   </Target>
 
   <UsingTask

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -15,7 +15,42 @@
     <_ILRepackToolTaskAssembly Condition="!Exists('$(_ILRepackToolTaskAssembly)')">$(_ILRepackToolTaskAssemblyPackage)</_ILRepackToolTaskAssembly>
     <_ILRepackToolTaskAssembly Condition="!Exists('$(_ILRepackToolTaskAssembly)')">$(_ILRepackToolTaskAssemblyArtifact)</_ILRepackToolTaskAssembly>
     <_ILRepackToolTaskAssembly Condition="!Exists('$(_ILRepackToolTaskAssembly)')">$(_ILRepackToolTaskAssemblyArtifactLowerCase)</_ILRepackToolTaskAssembly>
+
+
+    <_MsBuildAssembly>$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll</_MsBuildAssembly>
+    <_MsBuildTaskFactory>CodeTaskFactory</_MsBuildTaskFactory>
+    <_MsBuildTaskFactory Condition=" '$(MSBuildVersion.Substring(0,2))' >= 16 Or ('$(MSBuildVersion.Substring(0,2))' == 15 And '$(MSBuildVersion.Substring(3,1))' >= 8)">RoslynCodeTaskFactory</_MsBuildTaskFactory>
+
   </PropertyGroup>
+
+  <UsingTask
+    TaskName="LocateToolFile"
+    TaskFactory="$(_MsBuildTaskFactory)"
+    AssemblyFile="$(_MsBuildAssembly)">
+    <ParameterGroup>
+      <RootDir ParameterType="System.String" Required="true" />
+      <FileName ParameterType="System.String" Required="true" />
+      <Files ParameterType="System.String[]" Required="false" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System" />
+      <Using Namespace="System.Diagnostics" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Linq" />
+      <Using Namespace="System.Collections.Generic" />
+      <Using Namespace="System.Text.RegularExpressions" />
+      <Code Type="Fragment" Language="cs">
+      <![CDATA[
+        Log.LogMessage(MessageImportance.High, $"LocateToolFile: looking for {FileName} in {RootDir} and below");
+        Files = Directory.EnumerateFiles(RootDir, FileName, SearchOption.AllDirectories).ToArray();
+        foreach(var file in Files)
+        {
+          Log.LogMessage(MessageImportance.High, $"LocateToolFile[{FileName}]: found {file}");
+        }
+      ]]>
+      </Code>
+    </Task>
+  </UsingTask>
 
   <Target Name="ILRepackToolInfo" BeforeTargets="Compile">
     <Message Text="_ILRepackToolTaskAssemblyLocal: $(_ILRepackToolTaskAssemblyLocal)" Importance="high" />


### PR DESCRIPTION
- **feat: implement `LocateToolFile` task to retrieve assembly**
- **build: call `LocateToolFile` to locate assembly in potential output folders**
- **feat: implement `LocateLibFile` task to retrieve assembly**
- **build: call `LocateLibFile` to locate assembly in potential output folders**
