### PR TITLE
build: change assembly paths order to handle the package paths first

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -3,16 +3,16 @@
 
   <PropertyGroup>
     <_ILRepackLibTaskAssemblyFile>ILRepack.Lib.MSBuild.Task.dll</_ILRepackLibTaskAssemblyFile>
+    <_ILRepackLibTaskAssemblyPackage>$(MSBuildThisFileDirectory)..\lib\netstandard2.0\$(_ILRepackLibTaskAssemblyFile)</_ILRepackLibTaskAssemblyPackage>
     <_ILRepackLibTaskAssemblyLocal>$(OutDir)$(_ILRepackLibTaskAssemblyFile)</_ILRepackLibTaskAssemblyLocal>
     <_ILRepackLibTaskAssemblyLocalRelative>$(MSBuildThisFileDirectory)..\$(_ILRepackLibTaskAssemblyFile)</_ILRepackLibTaskAssemblyLocalRelative>
-    <_ILRepackLibTaskAssemblyPackage>$(MSBuildThisFileDirectory)..\lib\netstandard2.0\$(_ILRepackLibTaskAssemblyFile)</_ILRepackLibTaskAssemblyPackage>
     <_ILRepackLibTaskAssemblyArtifact>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Lib.MSBuild.Task\$(Configuration)\$(_ILRepackLibTaskAssemblyFile)</_ILRepackLibTaskAssemblyArtifact>
     <_ILRepackLibTaskAssemblyArtifactLowerCase>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Lib.MSBuild.Task\$(Configuration.ToLowerInvariant())\$(_ILRepackLibTaskAssemblyFile)</_ILRepackLibTaskAssemblyArtifactLowerCase>
 
-    <_ILRepackLibTaskAssembly>$(_ILRepackLibTaskAssemblyArtifactLowerCase)</_ILRepackLibTaskAssembly>
+    <_ILRepackLibTaskAssembly>$(_ILRepackLibTaskAssemblyPackage)</_ILRepackLibTaskAssembly>
+    <_ILRepackLibTaskAssembly Condition="!Exists('$(_ILRepackLibTaskAssembly)')">$(_ILRepackLibTaskAssemblyPackage)</_ILRepackLibTaskAssembly>
     <_ILRepackLibTaskAssembly Condition="!Exists('$(_ILRepackLibTaskAssembly)')">$(_ILRepackLibTaskAssemblyLocal)</_ILRepackLibTaskAssembly>
     <_ILRepackLibTaskAssembly Condition="!Exists('$(_ILRepackLibTaskAssembly)')">$(_ILRepackLibTaskAssemblyLocalRelative)</_ILRepackLibTaskAssembly>
-    <_ILRepackLibTaskAssembly Condition="!Exists('$(_ILRepackLibTaskAssembly)')">$(_ILRepackLibTaskAssemblyPackage)</_ILRepackLibTaskAssembly>
     <_ILRepackLibTaskAssembly Condition="!Exists('$(_ILRepackLibTaskAssembly)')">$(_ILRepackLibTaskAssemblyArtifact)</_ILRepackLibTaskAssembly>
     <_ILRepackLibTaskAssembly Condition="!Exists('$(_ILRepackLibTaskAssembly)')">$(_ILRepackLibTaskAssemblyArtifactLowerCase)</_ILRepackLibTaskAssembly>
 

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -3,16 +3,16 @@
 
   <PropertyGroup>
     <_ILRepackToolTaskAssemblyFile>ILRepack.Tool.MSBuild.Task.dll</_ILRepackToolTaskAssemblyFile>
+    <_ILRepackToolTaskAssemblyPackage>$(MSBuildThisFileDirectory)..\lib\netstandard2.0\$(_ILRepackToolTaskAssemblyFile)</_ILRepackToolTaskAssemblyPackage>
     <_ILRepackToolTaskAssemblyLocal>$(OutDir)$(_ILRepackToolTaskAssemblyFile)</_ILRepackToolTaskAssemblyLocal>
     <_ILRepackToolTaskAssemblyLocalRelative>$(MSBuildThisFileDirectory)..\$(_ILRepackToolTaskAssemblyFile)</_ILRepackToolTaskAssemblyLocalRelative>
-    <_ILRepackToolTaskAssemblyPackage>$(MSBuildThisFileDirectory)..\lib\netstandard2.0\$(_ILRepackToolTaskAssemblyFile)</_ILRepackToolTaskAssemblyPackage>
     <_ILRepackToolTaskAssemblyArtifact>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Tool.MSBuild.Task\$(Configuration)\$(_ILRepackToolTaskAssemblyFile)</_ILRepackToolTaskAssemblyArtifact>
     <_ILRepackToolTaskAssemblyArtifactLowerCase>$(MSBuildThisFileDirectory)..\..\.artifacts\bin\ILRepack.Tool.MSBuild.Task\$(Configuration.ToLowerInvariant())\$(_ILRepackToolTaskAssemblyFile)</_ILRepackToolTaskAssemblyArtifactLowerCase>
 
-    <_ILRepackToolTaskAssembly>$(_ILRepackToolTaskAssemblyArtifactLowerCase)</_ILRepackToolTaskAssembly>
+    <_ILRepackToolTaskAssembly>$(_ILRepackToolTaskAssemblyPackage)</_ILRepackToolTaskAssembly>
+    <_ILRepackToolTaskAssembly Condition="!Exists('$(_ILRepackToolTaskAssembly)')">$(_ILRepackToolTaskAssemblyPackage)</_ILRepackToolTaskAssembly>
     <_ILRepackToolTaskAssembly Condition="!Exists('$(_ILRepackToolTaskAssembly)')">$(_ILRepackToolTaskAssemblyLocal)</_ILRepackToolTaskAssembly>
     <_ILRepackToolTaskAssembly Condition="!Exists('$(_ILRepackToolTaskAssembly)')">$(_ILRepackToolTaskAssemblyLocalRelative)</_ILRepackToolTaskAssembly>
-    <_ILRepackToolTaskAssembly Condition="!Exists('$(_ILRepackToolTaskAssembly)')">$(_ILRepackToolTaskAssemblyPackage)</_ILRepackToolTaskAssembly>
     <_ILRepackToolTaskAssembly Condition="!Exists('$(_ILRepackToolTaskAssembly)')">$(_ILRepackToolTaskAssemblyArtifact)</_ILRepackToolTaskAssembly>
     <_ILRepackToolTaskAssembly Condition="!Exists('$(_ILRepackToolTaskAssembly)')">$(_ILRepackToolTaskAssemblyArtifactLowerCase)</_ILRepackToolTaskAssembly>
 


### PR DESCRIPTION
- **build: change assembly path order for `ILRepack.Tool.MSBuild.Task.dll` to handle the package path first**
- **build: change assembly path order for `ILRepack.Lib.MSBuild.Task.dll` to handle the package path first**
