### PR TITLE
build: change parameters passed to `ILRepack` from unit test projects

### DIFF
--- a/Tests/Repack.Lib.Test/ILRepack.targets
+++ b/Tests/Repack.Lib.Test/ILRepack.targets
@@ -31,6 +31,7 @@
       InputAssemblies="@(MainAssembly);@(InputAssemblies)"
       InternalizeExclude="@(DoNotInternalizeAssemblies)"
       FilterAssemblies="@(FilterAssemblies)"
+      Timeout="60"
 
       OutputFile="@(MainAssembly)"
       LogFile="$(OutputPath)$(AssemblyName).ilrepack.log"

--- a/Tests/Repack.Lib.Test/ILRepack.targets
+++ b/Tests/Repack.Lib.Test/ILRepack.targets
@@ -25,7 +25,7 @@
     <ILRepack
       Parallel="false"
       DebugInfo="true"
-      Verbose="true"
+      Verbose="false"
       Internalize="true"
       RenameInternalized="false"
       InputAssemblies="@(MainAssembly);@(InputAssemblies)"

--- a/Tests/Repack.Tool.Test/ILRepack.targets
+++ b/Tests/Repack.Tool.Test/ILRepack.targets
@@ -31,6 +31,7 @@
       InputAssemblies="@(MainAssembly);@(InputAssemblies)"
       InternalizeExclude="@(DoNotInternalizeAssemblies)"
       FilterAssemblies="@(FilterAssemblies)"
+      Timeout="60"
 
       OutputFile="@(MainAssembly)"
       LogFile="$(OutputPath)$(AssemblyName).ilrepack.log"

--- a/Tests/Repack.Tool.Test/ILRepack.targets
+++ b/Tests/Repack.Tool.Test/ILRepack.targets
@@ -25,7 +25,7 @@
     <ILRepack
       Parallel="false"
       DebugInfo="true"
-      Verbose="true"
+      Verbose="false"
       Internalize="true"
       RenameInternalized="false"
       InputAssemblies="@(MainAssembly);@(InputAssemblies)"


### PR DESCRIPTION
- **build(Repack.Tool.Test): pass parameter `Timeout = 60` to `ILRepack`**
- **build(Repack.Tool.Test): pass parameter `Verbose = false` to `ILRepack`**
- **build(Repack.Lib.Test): pass parameter `Timeout = 60` to `ILRepack`**
- **build(Repack.Lib.Test): pass parameter `Verbose = false` to `ILRepack`**
