### PR TITLE
build: define default targets for ILRepack tasks

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
@@ -29,6 +29,8 @@
          By convention, the .NET SDK will look for build\<Package Id>.props and build\<Package Id>.targets
          for automatic inclusion in the build.
     -->
+    <Content Include="$(MSBuildThisFileDirectory)build\KageKirin.ILRepack.Lib.MSBuild.Task.props" PackagePath="build" Link="build\KageKirin.ILRepack.Lib.MSBuild.Task.props" Pack="true" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(MSBuildThisFileDirectory)build\KageKirin.ILRepack.Lib.MSBuild.Task.props" PackagePath="tools" Link="tools\KageKirin.ILRepack.Lib.MSBuild.Task.props" Pack="true" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="$(MSBuildThisFileDirectory)build\KageKirin.ILRepack.Lib.MSBuild.Task.targets" PackagePath="build" Link="build\KageKirin.ILRepack.Lib.MSBuild.Task.targets" Pack="true" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="$(MSBuildThisFileDirectory)build\KageKirin.ILRepack.Lib.MSBuild.Task.targets" PackagePath="tools" Link="tools\KageKirin.ILRepack.Lib.MSBuild.Task.targets" Pack="true" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <ILRepackTarget Condition="'$(ILRepackTarget)' == ''">false</ILRepackTarget>
+    <ILRepackTarget Condition="'$(ILRepackTarget)' == 'disable'">false</ILRepackTarget>
+    <ILRepackTarget Condition="'$(ILRepackTarget)' == 'enable'">true</ILRepackTarget>
+
+    <ILRepackParallel Condition="'$(ILRepackParallel)' == ''">false</ILRepackParallel>
+    <ILRepackParallel Condition="'$(ILRepackParallel)' == 'disable'">false</ILRepackParallel>
+    <ILRepackParallel Condition="'$(ILRepackParallel)' == 'enable'">true</ILRepackParallel>
+
+    <ILRepackDebugInfo Condition="'$(ILRepackDebugInfo)' == ''">false</ILRepackDebugInfo>
+    <ILRepackDebugInfo Condition="'$(ILRepackDebugInfo)' == 'disable'">false</ILRepackDebugInfo>
+    <ILRepackDebugInfo Condition="'$(ILRepackDebugInfo)' == 'enable'">true</ILRepackDebugInfo>
+
+    <ILRepackVerbose Condition="'$(ILRepackVerbose)' == ''">false</ILRepackVerbose>
+    <ILRepackVerbose Condition="'$(ILRepackVerbose)' == 'disable'">false</ILRepackVerbose>
+    <ILRepackVerbose Condition="'$(ILRepackVerbose)' == 'enable'">true</ILRepackVerbose>
+
+    <ILRepackInternalize Condition="'$(ILRepackInternalize)' == ''">false</ILRepackInternalize>
+    <ILRepackInternalize Condition="'$(ILRepackInternalize)' == 'disable'">false</ILRepackInternalize>
+    <ILRepackInternalize Condition="'$(ILRepackInternalize)' == 'enable'">true</ILRepackInternalize>
+
+    <ILRepackRenameInternalized Condition="'$(ILRepackRenameInternalized)' == ''">false</ILRepackRenameInternalized>
+    <ILRepackRenameInternalized Condition="'$(ILRepackRenameInternalized)' == 'disable'">false</ILRepackRenameInternalized>
+    <ILRepackRenameInternalized Condition="'$(ILRepackRenameInternalized)' == 'enable'">true</ILRepackRenameInternalized>
+
+    <ILRepackWildcards Condition="'$(ILRepackWildcards)' == ''">false</ILRepackWildcards>
+    <ILRepackWildcards Condition="'$(ILRepackWildcards)' == 'disable'">false</ILRepackWildcards>
+    <ILRepackWildcards Condition="'$(ILRepackWildcards)' == 'enable'">true</ILRepackWildcards>
+
+    <ILRepackDelaySign Condition="'$(ILRepackDelaySign)' == ''">false</ILRepackDelaySign>
+    <ILRepackDelaySign Condition="'$(ILRepackDelaySign)' == 'disable'">false</ILRepackDelaySign>
+    <ILRepackDelaySign Condition="'$(ILRepackDelaySign)' == 'enable'">true</ILRepackDelaySign>
+
+    <ILRepackExcludeInternalizeSerializable Condition="'$(ILRepackExcludeInternalizeSerializable)' == ''">false</ILRepackExcludeInternalizeSerializable>
+    <ILRepackExcludeInternalizeSerializable Condition="'$(ILRepackExcludeInternalizeSerializable)' == 'disable'">false</ILRepackExcludeInternalizeSerializable>
+    <ILRepackExcludeInternalizeSerializable Condition="'$(ILRepackExcludeInternalizeSerializable)' == 'enable'">true</ILRepackExcludeInternalizeSerializable>
+
+    <ILRepackUnion Condition="'$(ILRepackUnion)' == ''">false</ILRepackUnion>
+    <ILRepackUnion Condition="'$(ILRepackUnion)' == 'disable'">false</ILRepackUnion>
+    <ILRepackUnion Condition="'$(ILRepackUnion)' == 'enable'">true</ILRepackUnion>
+
+    <ILRepackAllowDup Condition="'$(ILRepackAllowDup)' == ''">false</ILRepackAllowDup>
+    <ILRepackAllowDup Condition="'$(ILRepackAllowDup)' == 'disable'">false</ILRepackAllowDup>
+    <ILRepackAllowDup Condition="'$(ILRepackAllowDup)' == 'enable'">true</ILRepackAllowDup>
+
+    <ILRepackAllowDuplicateResources Condition="'$(ILRepackAllowDuplicateResources)' == ''">false</ILRepackAllowDuplicateResources>
+    <ILRepackAllowDuplicateResources Condition="'$(ILRepackAllowDuplicateResources)' == 'disable'">false</ILRepackAllowDuplicateResources>
+    <ILRepackAllowDuplicateResources Condition="'$(ILRepackAllowDuplicateResources)' == 'enable'">true</ILRepackAllowDuplicateResources>
+
+    <ILRepackNoRepackRes Condition="'$(ILRepackNoRepackRes)' == ''">false</ILRepackNoRepackRes>
+    <ILRepackNoRepackRes Condition="'$(ILRepackNoRepackRes)' == 'disable'">false</ILRepackNoRepackRes>
+    <ILRepackNoRepackRes Condition="'$(ILRepackNoRepackRes)' == 'enable'">true</ILRepackNoRepackRes>
+
+    <ILRepackCopyAttrs Condition="'$(ILRepackCopyAttrs)' == ''">false</ILRepackCopyAttrs>
+    <ILRepackCopyAttrs Condition="'$(ILRepackCopyAttrs)' == 'disable'">false</ILRepackCopyAttrs>
+    <ILRepackCopyAttrs Condition="'$(ILRepackCopyAttrs)' == 'enable'">true</ILRepackCopyAttrs>
+
+    <ILRepackAllowMultiple Condition="'$(ILRepackAllowMultiple)' == ''">false</ILRepackAllowMultiple>
+    <ILRepackAllowMultiple Condition="'$(ILRepackAllowMultiple)' == 'disable'">false</ILRepackAllowMultiple>
+    <ILRepackAllowMultiple Condition="'$(ILRepackAllowMultiple)' == 'enable'">true</ILRepackAllowMultiple>
+
+    <ILRepackKeepOtherVersionReferences Condition="'$(ILRepackKeepOtherVersionReferences)' == ''">false</ILRepackKeepOtherVersionReferences>
+    <ILRepackKeepOtherVersionReferences Condition="'$(ILRepackKeepOtherVersionReferences)' == 'disable'">false</ILRepackKeepOtherVersionReferences>
+    <ILRepackKeepOtherVersionReferences Condition="'$(ILRepackKeepOtherVersionReferences)' == 'enable'">true</ILRepackKeepOtherVersionReferences>
+
+    <ILRepackPreserveTimestamp Condition="'$(ILRepackPreserveTimestamp)' == ''">false</ILRepackPreserveTimestamp>
+    <ILRepackPreserveTimestamp Condition="'$(ILRepackPreserveTimestamp)' == 'disable'">false</ILRepackPreserveTimestamp>
+    <ILRepackPreserveTimestamp Condition="'$(ILRepackPreserveTimestamp)' == 'enable'">true</ILRepackPreserveTimestamp>
+
+    <ILRepackSkipConfig Condition="'$(ILRepackSkipConfig)' == ''">false</ILRepackSkipConfig>
+    <ILRepackSkipConfig Condition="'$(ILRepackSkipConfig)' == 'disable'">false</ILRepackSkipConfig>
+    <ILRepackSkipConfig Condition="'$(ILRepackSkipConfig)' == 'enable'">true</ILRepackSkipConfig>
+
+    <ILRepackILLink Condition="'$(ILRepackILLink)' == ''">false</ILRepackILLink>
+    <ILRepackILLink Condition="'$(ILRepackILLink)' == 'disable'">false</ILRepackILLink>
+    <ILRepackILLink Condition="'$(ILRepackILLink)' == 'enable'">true</ILRepackILLink>
+
+    <ILRepackXmlDocs Condition="'$(ILRepackXmlDocs)' == ''">false</ILRepackXmlDocs>
+    <ILRepackXmlDocs Condition="'$(ILRepackXmlDocs)' == 'disable'">false</ILRepackXmlDocs>
+    <ILRepackXmlDocs Condition="'$(ILRepackXmlDocs)' == 'enable'">true</ILRepackXmlDocs>
+
+    <ILRepackZeroPEKind Condition="'$(ILRepackZeroPEKind)' == ''">false</ILRepackZeroPEKind>
+    <ILRepackZeroPEKind Condition="'$(ILRepackZeroPEKind)' == 'disable'">false</ILRepackZeroPEKind>
+    <ILRepackZeroPEKind Condition="'$(ILRepackZeroPEKind)' == 'enable'">true</ILRepackZeroPEKind>
+
+    <ILRepackTimeout Condition="'$(ILRepackTimeout)' == ''">30</ILRepackTimeout>
+    <ILRepackTimeout Condition="$([System.Int32]::TryParse('$(ILRepackTimeout)', null))">30</ILRepackTimeout>
+
+    <ILRepackVersion Condition="$([System.Version]::TryParse('$(ILRepackVersion)', null))"></ILRepackVersion>
+
+    <ILRepackTargetKind Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(ILRepackTargetKind)', 'dll|exe'))"></ILRepackTargetKind>
+
+
+
+    <ILRepackIncludeReferenceAssemblies Condition="'$(ILRepackIncludeReferenceAssemblies)' == ''">false</ILRepackIncludeReferenceAssemblies>
+    <ILRepackIncludeReferenceAssemblies Condition="'$(ILRepackIncludeReferenceAssemblies)' == 'disable'">false</ILRepackIncludeReferenceAssemblies>
+    <ILRepackIncludeReferenceAssemblies Condition="'$(ILRepackIncludeReferenceAssemblies)' == 'enable'">true</ILRepackIncludeReferenceAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ILRepackOutputFile Condition="'$(ILRepackOutputFile)' == ''" Include="$(OutDir)Repacked.$(AssemblyFile)" />
+    <ILRepackLogFile Condition="'$(ILRepackLogFile)' == ''" Include="$(OutDir)$(AssemblyName).ilrepack.log" />
+  </ItemGroup>
+
+ <!--
+  <ItemGroup Label="many files">
+    <ILRepackInputAssemblies Include="" />
+    <ILRepackLibraryPaths Include="" />
+    <ILRepackInternalizeExclude Include="" />
+    <ILRepackImportAttributeAssemblies Include="" />
+    <ILRepackInternalizeAssemblies Include="" />
+    <ILRepackRepackDropAttributes Include="" />
+    <ILRepackAllowedDuplicateTypes Include="" />
+  </ItemGroup>
+
+  <ItemGroup Label="regex or assembly name">
+    <ILRepackFilterAssemblies Include="" />
+  </ItemGroup>
+
+  <ItemGroup Label="single file">
+    <ILRepackKeyFile Include="" />
+    <ILRepackKeyContainer Include="" />
+  </ItemGroup>
+ -->
+
+</Project>

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -29,4 +29,67 @@
 
   <Import Project="$(_ILRepackConfigProps)" Condition="'$(_ILRepackConfigProps)' != '' and Exists('$(_ILRepackConfigProps)')"/>
   <Import Project="$(_ILRepackTargets)" Condition="'$(_ILRepackTargets)' != '' and Exists('$(_ILRepackTargets)')"/>
+
+  <Target
+    Name="ILRepackingWithLib"
+    AfterTargets="Compile"
+    DependsOnTargets="ResolveAssemblyReferences"
+    Condition="'$(ILRepackTarget)' == 'true'">
+
+    <Message Text="Repacking $(IntermediateOutputPath)" Importance="high" />
+
+    <ItemGroup>
+      <_MainAssembly Include="$(IntermediateOutputPath)$(TargetFileName)" />
+      <_InputAssemblies Include="@(ILRepackInputAssemblies)" />
+      <_InputAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="'$(ILRepackIncludeReferenceAssemblies)' == 'true'" />
+
+      <_FilterAssemblies Include="$(AssemblyName)" />
+      <_FilterAssemblies Include="@(ILRepackFilterAssemblies)" />
+
+      <_LibraryPaths Include="%(ILRepackLibraryPaths.Directory)" />
+      <_LibraryPaths Include="%(_InputAssemblies.Directory)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_DoNotInternalizeAssemblies Include="@(_MainAssembly)" />
+    </ItemGroup>
+
+    <Message Text="Repacking assemblies in $(IntermediateOutputPath): @(_InputAssemblies->'%(Identity)', ' ') into @(_MainAssembly->'%(Identity)')" Importance="high" />
+
+    <ILRepack
+      Parallel="$(ILRepackParallel)"
+      DebugInfo="$(ILRepackDebugInfo)"
+      Verbose="$(ILRepackVerbose)"
+      Internalize="$(ILRepackInternalize)"
+      RenameInternalized="$(ILRepackRenameInternalized)"
+      Wildcards="$(ILRepackWildcards)"
+      DelaySign="$(ILRepackDelaySign)"
+      ExcludeInternalizeSerializable="$(ILRepackExcludeInternalizeSerializable)"
+      Union="$(ILRepackUnion)"
+      AllowDup="$(ILRepackAllowDup)"
+      AllowDuplicateResources="$(ILRepackAllowDuplicateResources)"
+      NoRepackRes="$(ILRepackNoRepackRes)"
+      CopyAttrs="$(ILRepackCopyAttrs)"
+      AllowMultiple="$(ILRepackAllowMultiple)"
+      KeepOtherVersionReferences="$(ILRepackKeepOtherVersionReferences)"
+      PreserveTimestamp="$(ILRepackPreserveTimestamp)"
+      SkipConfig="$(ILRepackSkipConfig)"
+      ILLink="$(ILRepackILLink)"
+      XmlDocs="$(ILRepackXmlDocs)"
+      ZeroPEKind="$(ILRepackZeroPEKind)"
+      Timeout="$(ILRepackTimeout)"
+      Version="$(ILRepackVersion)"
+      TargetKind="$(ILRepackTargetKind)"
+
+      InputAssemblies="@(_MainAssembly);@(_InputAssemblies)"
+      InternalizeExclude="@(_DoNotInternalizeAssemblies)"
+      FilterAssemblies="@(_FilterAssemblies)"
+      LibraryPaths="@(_LibraryPaths)"
+
+      OutputFile="@(ILRepackOutputFile)"
+      LogFile="@(ILRepackLogFile)"
+    />
+
+  </Target>
+
 </Project>

--- a/ILRepack.MSBuild.Task.all.slnf
+++ b/ILRepack.MSBuild.Task.all.slnf
@@ -8,7 +8,8 @@
       "Tests\\Repack.Tool.Test\\Repack.Tool.Test.csproj",
       "Tests\\Repack.Lib.Test\\Repack.Lib.Test.csproj",
       "Tests\\Repack.Tool.RefOnly.Test\\Repack.Tool.RefOnly.Test.csproj",
-      "Tests\\Repack.Lib.RefOnly.Test\\Repack.Lib.RefOnly.Test.csproj"
+      "Tests\\Repack.Lib.RefOnly.Test\\Repack.Lib.RefOnly.Test.csproj",
+      "Tests\\Repack.Tool.Target.Test\\Repack.Tool.Target.Test.csproj"
     ]
   }
 }

--- a/ILRepack.MSBuild.Task.all.slnf
+++ b/ILRepack.MSBuild.Task.all.slnf
@@ -9,7 +9,8 @@
       "Tests\\Repack.Lib.Test\\Repack.Lib.Test.csproj",
       "Tests\\Repack.Tool.RefOnly.Test\\Repack.Tool.RefOnly.Test.csproj",
       "Tests\\Repack.Lib.RefOnly.Test\\Repack.Lib.RefOnly.Test.csproj",
-      "Tests\\Repack.Tool.Target.Test\\Repack.Tool.Target.Test.csproj"
+      "Tests\\Repack.Tool.Target.Test\\Repack.Tool.Target.Test.csproj",
+      "Tests\\Repack.Lib.Target.Test\\Repack.Lib.Target.Test.csproj"
     ]
   }
 }

--- a/ILRepack.MSBuild.Task.sln
+++ b/ILRepack.MSBuild.Task.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Repack.Tool.RefOnly.Test", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Repack.Lib.RefOnly.Test", "Tests\Repack.Lib.RefOnly.Test\Repack.Lib.RefOnly.Test.csproj", "{CE5E44E4-F0FD-42DC-AFF8-F4701C6399DB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Repack.Tool.Target.Test", "Tests\Repack.Tool.Target.Test\Repack.Tool.Target.Test.csproj", "{1AEBCF4D-B852-4B48-A7A1-213459983C1F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -113,6 +115,18 @@ Global
 		{CE5E44E4-F0FD-42DC-AFF8-F4701C6399DB}.Release|x64.Build.0 = Release|Any CPU
 		{CE5E44E4-F0FD-42DC-AFF8-F4701C6399DB}.Release|x86.ActiveCfg = Release|Any CPU
 		{CE5E44E4-F0FD-42DC-AFF8-F4701C6399DB}.Release|x86.Build.0 = Release|Any CPU
+		{1AEBCF4D-B852-4B48-A7A1-213459983C1F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1AEBCF4D-B852-4B48-A7A1-213459983C1F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1AEBCF4D-B852-4B48-A7A1-213459983C1F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1AEBCF4D-B852-4B48-A7A1-213459983C1F}.Debug|x64.Build.0 = Debug|Any CPU
+		{1AEBCF4D-B852-4B48-A7A1-213459983C1F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1AEBCF4D-B852-4B48-A7A1-213459983C1F}.Debug|x86.Build.0 = Debug|Any CPU
+		{1AEBCF4D-B852-4B48-A7A1-213459983C1F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1AEBCF4D-B852-4B48-A7A1-213459983C1F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1AEBCF4D-B852-4B48-A7A1-213459983C1F}.Release|x64.ActiveCfg = Release|Any CPU
+		{1AEBCF4D-B852-4B48-A7A1-213459983C1F}.Release|x64.Build.0 = Release|Any CPU
+		{1AEBCF4D-B852-4B48-A7A1-213459983C1F}.Release|x86.ActiveCfg = Release|Any CPU
+		{1AEBCF4D-B852-4B48-A7A1-213459983C1F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -123,5 +137,6 @@ Global
 		{AB11F283-E7C4-42EA-969A-258A56B66AD7} = {54749167-747B-4C31-94CC-AD76608E23F7}
 		{E44E145F-DCD4-42B5-94DF-C694844E6C11} = {54749167-747B-4C31-94CC-AD76608E23F7}
 		{CE5E44E4-F0FD-42DC-AFF8-F4701C6399DB} = {54749167-747B-4C31-94CC-AD76608E23F7}
+		{1AEBCF4D-B852-4B48-A7A1-213459983C1F} = {54749167-747B-4C31-94CC-AD76608E23F7}
 	EndGlobalSection
 EndGlobal

--- a/ILRepack.MSBuild.Task.sln
+++ b/ILRepack.MSBuild.Task.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Repack.Lib.RefOnly.Test", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Repack.Tool.Target.Test", "Tests\Repack.Tool.Target.Test\Repack.Tool.Target.Test.csproj", "{1AEBCF4D-B852-4B48-A7A1-213459983C1F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Repack.Lib.Target.Test", "Tests\Repack.Lib.Target.Test\Repack.Lib.Target.Test.csproj", "{1BB59A3D-768A-44CF-B1F4-351774F8D2DC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -127,6 +129,18 @@ Global
 		{1AEBCF4D-B852-4B48-A7A1-213459983C1F}.Release|x64.Build.0 = Release|Any CPU
 		{1AEBCF4D-B852-4B48-A7A1-213459983C1F}.Release|x86.ActiveCfg = Release|Any CPU
 		{1AEBCF4D-B852-4B48-A7A1-213459983C1F}.Release|x86.Build.0 = Release|Any CPU
+		{1BB59A3D-768A-44CF-B1F4-351774F8D2DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1BB59A3D-768A-44CF-B1F4-351774F8D2DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1BB59A3D-768A-44CF-B1F4-351774F8D2DC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1BB59A3D-768A-44CF-B1F4-351774F8D2DC}.Debug|x64.Build.0 = Debug|Any CPU
+		{1BB59A3D-768A-44CF-B1F4-351774F8D2DC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1BB59A3D-768A-44CF-B1F4-351774F8D2DC}.Debug|x86.Build.0 = Debug|Any CPU
+		{1BB59A3D-768A-44CF-B1F4-351774F8D2DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1BB59A3D-768A-44CF-B1F4-351774F8D2DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1BB59A3D-768A-44CF-B1F4-351774F8D2DC}.Release|x64.ActiveCfg = Release|Any CPU
+		{1BB59A3D-768A-44CF-B1F4-351774F8D2DC}.Release|x64.Build.0 = Release|Any CPU
+		{1BB59A3D-768A-44CF-B1F4-351774F8D2DC}.Release|x86.ActiveCfg = Release|Any CPU
+		{1BB59A3D-768A-44CF-B1F4-351774F8D2DC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -138,5 +152,6 @@ Global
 		{E44E145F-DCD4-42B5-94DF-C694844E6C11} = {54749167-747B-4C31-94CC-AD76608E23F7}
 		{CE5E44E4-F0FD-42DC-AFF8-F4701C6399DB} = {54749167-747B-4C31-94CC-AD76608E23F7}
 		{1AEBCF4D-B852-4B48-A7A1-213459983C1F} = {54749167-747B-4C31-94CC-AD76608E23F7}
+		{1BB59A3D-768A-44CF-B1F4-351774F8D2DC} = {54749167-747B-4C31-94CC-AD76608E23F7}
 	EndGlobalSection
 EndGlobal

--- a/ILRepack.MSBuild.Task.tests.slnf
+++ b/ILRepack.MSBuild.Task.tests.slnf
@@ -7,7 +7,8 @@
       "Tests\\Repack.Lib.Test\\Repack.Lib.Test.csproj",
       "Tests\\Repack.Tool.RefOnly.Test\\Repack.Tool.RefOnly.Test.csproj",
       "Tests\\Repack.Lib.RefOnly.Test\\Repack.Lib.RefOnly.Test.csproj",
-      "Tests\\Repack.Tool.Target.Test\\Repack.Tool.Target.Test.csproj"
+      "Tests\\Repack.Tool.Target.Test\\Repack.Tool.Target.Test.csproj",
+      "Tests\\Repack.Lib.Target.Test\\Repack.Lib.Target.Test.csproj"
     ]
   }
 }

--- a/ILRepack.MSBuild.Task.tests.slnf
+++ b/ILRepack.MSBuild.Task.tests.slnf
@@ -6,7 +6,8 @@
       "Tests\\Repack.Tool.Test\\Repack.Tool.Test.csproj",
       "Tests\\Repack.Lib.Test\\Repack.Lib.Test.csproj",
       "Tests\\Repack.Tool.RefOnly.Test\\Repack.Tool.RefOnly.Test.csproj",
-      "Tests\\Repack.Lib.RefOnly.Test\\Repack.Lib.RefOnly.Test.csproj"
+      "Tests\\Repack.Lib.RefOnly.Test\\Repack.Lib.RefOnly.Test.csproj",
+      "Tests\\Repack.Tool.Target.Test\\Repack.Tool.Target.Test.csproj"
     ]
   }
 }

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.Tool.MSBuild.Task.csproj
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.Tool.MSBuild.Task.csproj
@@ -29,6 +29,8 @@
          By convention, the .NET SDK will look for build\<Package Id>.props and build\<Package Id>.targets
          for automatic inclusion in the build.
     -->
+    <Content Include="$(MSBuildThisFileDirectory)build\KageKirin.ILRepack.Tool.MSBuild.Task.props" PackagePath="build" Link="build\KageKirin.ILRepack.Tool.MSBuild.Task.props" Pack="true" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(MSBuildThisFileDirectory)build\KageKirin.ILRepack.Tool.MSBuild.Task.props" PackagePath="tools" Link="tools\KageKirin.ILRepack.Tool.MSBuild.Task.props" Pack="true" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="$(MSBuildThisFileDirectory)build\KageKirin.ILRepack.Tool.MSBuild.Task.targets" PackagePath="build" Link="build\KageKirin.ILRepack.Tool.MSBuild.Task.targets" Pack="true" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="$(MSBuildThisFileDirectory)build\KageKirin.ILRepack.Tool.MSBuild.Task.targets" PackagePath="tools" Link="tools\KageKirin.ILRepack.Tool.MSBuild.Task.targets" Pack="true" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <ILRepackTarget Condition="'$(ILRepackTarget)' == ''">false</ILRepackTarget>
+    <ILRepackTarget Condition="'$(ILRepackTarget)' == 'disable'">false</ILRepackTarget>
+    <ILRepackTarget Condition="'$(ILRepackTarget)' == 'enable'">true</ILRepackTarget>
+
+    <ILRepackParallel Condition="'$(ILRepackParallel)' == ''">false</ILRepackParallel>
+    <ILRepackParallel Condition="'$(ILRepackParallel)' == 'disable'">false</ILRepackParallel>
+    <ILRepackParallel Condition="'$(ILRepackParallel)' == 'enable'">true</ILRepackParallel>
+
+    <ILRepackDebugInfo Condition="'$(ILRepackDebugInfo)' == ''">false</ILRepackDebugInfo>
+    <ILRepackDebugInfo Condition="'$(ILRepackDebugInfo)' == 'disable'">false</ILRepackDebugInfo>
+    <ILRepackDebugInfo Condition="'$(ILRepackDebugInfo)' == 'enable'">true</ILRepackDebugInfo>
+
+    <ILRepackVerbose Condition="'$(ILRepackVerbose)' == ''">false</ILRepackVerbose>
+    <ILRepackVerbose Condition="'$(ILRepackVerbose)' == 'disable'">false</ILRepackVerbose>
+    <ILRepackVerbose Condition="'$(ILRepackVerbose)' == 'enable'">true</ILRepackVerbose>
+
+    <ILRepackInternalize Condition="'$(ILRepackInternalize)' == ''">false</ILRepackInternalize>
+    <ILRepackInternalize Condition="'$(ILRepackInternalize)' == 'disable'">false</ILRepackInternalize>
+    <ILRepackInternalize Condition="'$(ILRepackInternalize)' == 'enable'">true</ILRepackInternalize>
+
+    <ILRepackRenameInternalized Condition="'$(ILRepackRenameInternalized)' == ''">false</ILRepackRenameInternalized>
+    <ILRepackRenameInternalized Condition="'$(ILRepackRenameInternalized)' == 'disable'">false</ILRepackRenameInternalized>
+    <ILRepackRenameInternalized Condition="'$(ILRepackRenameInternalized)' == 'enable'">true</ILRepackRenameInternalized>
+
+    <ILRepackWildcards Condition="'$(ILRepackWildcards)' == ''">false</ILRepackWildcards>
+    <ILRepackWildcards Condition="'$(ILRepackWildcards)' == 'disable'">false</ILRepackWildcards>
+    <ILRepackWildcards Condition="'$(ILRepackWildcards)' == 'enable'">true</ILRepackWildcards>
+
+    <ILRepackDelaySign Condition="'$(ILRepackDelaySign)' == ''">false</ILRepackDelaySign>
+    <ILRepackDelaySign Condition="'$(ILRepackDelaySign)' == 'disable'">false</ILRepackDelaySign>
+    <ILRepackDelaySign Condition="'$(ILRepackDelaySign)' == 'enable'">true</ILRepackDelaySign>
+
+    <ILRepackExcludeInternalizeSerializable Condition="'$(ILRepackExcludeInternalizeSerializable)' == ''">false</ILRepackExcludeInternalizeSerializable>
+    <ILRepackExcludeInternalizeSerializable Condition="'$(ILRepackExcludeInternalizeSerializable)' == 'disable'">false</ILRepackExcludeInternalizeSerializable>
+    <ILRepackExcludeInternalizeSerializable Condition="'$(ILRepackExcludeInternalizeSerializable)' == 'enable'">true</ILRepackExcludeInternalizeSerializable>
+
+    <ILRepackUnion Condition="'$(ILRepackUnion)' == ''">false</ILRepackUnion>
+    <ILRepackUnion Condition="'$(ILRepackUnion)' == 'disable'">false</ILRepackUnion>
+    <ILRepackUnion Condition="'$(ILRepackUnion)' == 'enable'">true</ILRepackUnion>
+
+    <ILRepackAllowDup Condition="'$(ILRepackAllowDup)' == ''">false</ILRepackAllowDup>
+    <ILRepackAllowDup Condition="'$(ILRepackAllowDup)' == 'disable'">false</ILRepackAllowDup>
+    <ILRepackAllowDup Condition="'$(ILRepackAllowDup)' == 'enable'">true</ILRepackAllowDup>
+
+    <ILRepackAllowDuplicateResources Condition="'$(ILRepackAllowDuplicateResources)' == ''">false</ILRepackAllowDuplicateResources>
+    <ILRepackAllowDuplicateResources Condition="'$(ILRepackAllowDuplicateResources)' == 'disable'">false</ILRepackAllowDuplicateResources>
+    <ILRepackAllowDuplicateResources Condition="'$(ILRepackAllowDuplicateResources)' == 'enable'">true</ILRepackAllowDuplicateResources>
+
+    <ILRepackNoRepackRes Condition="'$(ILRepackNoRepackRes)' == ''">false</ILRepackNoRepackRes>
+    <ILRepackNoRepackRes Condition="'$(ILRepackNoRepackRes)' == 'disable'">false</ILRepackNoRepackRes>
+    <ILRepackNoRepackRes Condition="'$(ILRepackNoRepackRes)' == 'enable'">true</ILRepackNoRepackRes>
+
+    <ILRepackCopyAttrs Condition="'$(ILRepackCopyAttrs)' == ''">false</ILRepackCopyAttrs>
+    <ILRepackCopyAttrs Condition="'$(ILRepackCopyAttrs)' == 'disable'">false</ILRepackCopyAttrs>
+    <ILRepackCopyAttrs Condition="'$(ILRepackCopyAttrs)' == 'enable'">true</ILRepackCopyAttrs>
+
+    <ILRepackAllowMultiple Condition="'$(ILRepackAllowMultiple)' == ''">false</ILRepackAllowMultiple>
+    <ILRepackAllowMultiple Condition="'$(ILRepackAllowMultiple)' == 'disable'">false</ILRepackAllowMultiple>
+    <ILRepackAllowMultiple Condition="'$(ILRepackAllowMultiple)' == 'enable'">true</ILRepackAllowMultiple>
+
+    <ILRepackKeepOtherVersionReferences Condition="'$(ILRepackKeepOtherVersionReferences)' == ''">false</ILRepackKeepOtherVersionReferences>
+    <ILRepackKeepOtherVersionReferences Condition="'$(ILRepackKeepOtherVersionReferences)' == 'disable'">false</ILRepackKeepOtherVersionReferences>
+    <ILRepackKeepOtherVersionReferences Condition="'$(ILRepackKeepOtherVersionReferences)' == 'enable'">true</ILRepackKeepOtherVersionReferences>
+
+    <ILRepackPreserveTimestamp Condition="'$(ILRepackPreserveTimestamp)' == ''">false</ILRepackPreserveTimestamp>
+    <ILRepackPreserveTimestamp Condition="'$(ILRepackPreserveTimestamp)' == 'disable'">false</ILRepackPreserveTimestamp>
+    <ILRepackPreserveTimestamp Condition="'$(ILRepackPreserveTimestamp)' == 'enable'">true</ILRepackPreserveTimestamp>
+
+    <ILRepackSkipConfig Condition="'$(ILRepackSkipConfig)' == ''">false</ILRepackSkipConfig>
+    <ILRepackSkipConfig Condition="'$(ILRepackSkipConfig)' == 'disable'">false</ILRepackSkipConfig>
+    <ILRepackSkipConfig Condition="'$(ILRepackSkipConfig)' == 'enable'">true</ILRepackSkipConfig>
+
+    <ILRepackILLink Condition="'$(ILRepackILLink)' == ''">false</ILRepackILLink>
+    <ILRepackILLink Condition="'$(ILRepackILLink)' == 'disable'">false</ILRepackILLink>
+    <ILRepackILLink Condition="'$(ILRepackILLink)' == 'enable'">true</ILRepackILLink>
+
+    <ILRepackXmlDocs Condition="'$(ILRepackXmlDocs)' == ''">false</ILRepackXmlDocs>
+    <ILRepackXmlDocs Condition="'$(ILRepackXmlDocs)' == 'disable'">false</ILRepackXmlDocs>
+    <ILRepackXmlDocs Condition="'$(ILRepackXmlDocs)' == 'enable'">true</ILRepackXmlDocs>
+
+    <ILRepackZeroPEKind Condition="'$(ILRepackZeroPEKind)' == ''">false</ILRepackZeroPEKind>
+    <ILRepackZeroPEKind Condition="'$(ILRepackZeroPEKind)' == 'disable'">false</ILRepackZeroPEKind>
+    <ILRepackZeroPEKind Condition="'$(ILRepackZeroPEKind)' == 'enable'">true</ILRepackZeroPEKind>
+
+    <ILRepackTimeout Condition="'$(ILRepackTimeout)' == ''">30</ILRepackTimeout>
+    <ILRepackTimeout Condition="$([System.Int32]::TryParse('$(ILRepackTimeout)', null))">30</ILRepackTimeout>
+
+    <ILRepackVersion Condition="$([System.Version]::TryParse('$(ILRepackVersion)', null))"></ILRepackVersion>
+
+    <ILRepackTargetKind Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(ILRepackTargetKind)', 'dll|exe'))"></ILRepackTargetKind>
+
+
+
+    <ILRepackIncludeReferenceAssemblies Condition="'$(ILRepackIncludeReferenceAssemblies)' == ''">false</ILRepackIncludeReferenceAssemblies>
+    <ILRepackIncludeReferenceAssemblies Condition="'$(ILRepackIncludeReferenceAssemblies)' == 'disable'">false</ILRepackIncludeReferenceAssemblies>
+    <ILRepackIncludeReferenceAssemblies Condition="'$(ILRepackIncludeReferenceAssemblies)' == 'enable'">true</ILRepackIncludeReferenceAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ILRepackOutputFile Condition="'$(ILRepackOutputFile)' == ''" Include="$(OutDir)Repacked.$(AssemblyFile)" />
+    <ILRepackLogFile Condition="'$(ILRepackLogFile)' == ''" Include="$(OutDir)$(AssemblyName).ilrepack.log" />
+  </ItemGroup>
+
+ <!--
+  <ItemGroup Label="many files">
+    <ILRepackInputAssemblies Include="" />
+    <ILRepackLibraryPaths Include="" />
+    <ILRepackInternalizeExclude Include="" />
+    <ILRepackImportAttributeAssemblies Include="" />
+    <ILRepackInternalizeAssemblies Include="" />
+    <ILRepackRepackDropAttributes Include="" />
+    <ILRepackAllowedDuplicateTypes Include="" />
+  </ItemGroup>
+
+  <ItemGroup Label="regex or assembly name">
+    <ILRepackFilterAssemblies Include="" />
+  </ItemGroup>
+
+  <ItemGroup Label="single file">
+    <ILRepackKeyFile Include="" />
+    <ILRepackKeyContainer Include="" />
+  </ItemGroup>
+ -->
+
+</Project>

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -29,4 +29,67 @@
 
   <Import Project="$(_ILRepackConfigProps)" Condition="'$(_ILRepackConfigProps)' != '' and Exists('$(_ILRepackConfigProps)')"/>
   <Import Project="$(_ILRepackTargets)" Condition="'$(_ILRepackTargets)' != '' and Exists('$(_ILRepackTargets)')"/>
+
+  <Target
+    Name="ILRepackingWithTool"
+    AfterTargets="Compile"
+    DependsOnTargets="ResolveAssemblyReferences"
+    Condition="'$(ILRepackTarget)' == 'true'">
+
+    <Message Text="Repacking $(IntermediateOutputPath)" Importance="high" />
+
+    <ItemGroup>
+      <_MainAssembly Include="$(IntermediateOutputPath)$(TargetFileName)" />
+      <_InputAssemblies Include="@(ILRepackInputAssemblies)" />
+      <_InputAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="'$(ILRepackIncludeReferenceAssemblies)' == 'true'" />
+
+      <_FilterAssemblies Include="$(AssemblyName)" />
+      <_FilterAssemblies Include="@(ILRepackFilterAssemblies)" />
+
+      <_LibraryPaths Include="%(ILRepackLibraryPaths.Directory)" />
+      <_LibraryPaths Include="%(_InputAssemblies.Directory)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_DoNotInternalizeAssemblies Include="@(_MainAssembly)" />
+    </ItemGroup>
+
+    <Message Text="Repacking assemblies in $(IntermediateOutputPath): @(_InputAssemblies->'%(Identity)', ' ') into @(_MainAssembly->'%(Identity)')" Importance="high" />
+
+    <ILRepack
+      Parallel="$(ILRepackParallel)"
+      DebugInfo="$(ILRepackDebugInfo)"
+      Verbose="$(ILRepackVerbose)"
+      Internalize="$(ILRepackInternalize)"
+      RenameInternalized="$(ILRepackRenameInternalized)"
+      Wildcards="$(ILRepackWildcards)"
+      DelaySign="$(ILRepackDelaySign)"
+      ExcludeInternalizeSerializable="$(ILRepackExcludeInternalizeSerializable)"
+      Union="$(ILRepackUnion)"
+      AllowDup="$(ILRepackAllowDup)"
+      AllowDuplicateResources="$(ILRepackAllowDuplicateResources)"
+      NoRepackRes="$(ILRepackNoRepackRes)"
+      CopyAttrs="$(ILRepackCopyAttrs)"
+      AllowMultiple="$(ILRepackAllowMultiple)"
+      KeepOtherVersionReferences="$(ILRepackKeepOtherVersionReferences)"
+      PreserveTimestamp="$(ILRepackPreserveTimestamp)"
+      SkipConfig="$(ILRepackSkipConfig)"
+      ILLink="$(ILRepackILLink)"
+      XmlDocs="$(ILRepackXmlDocs)"
+      ZeroPEKind="$(ILRepackZeroPEKind)"
+      Timeout="$(ILRepackTimeout)"
+      Version="$(ILRepackVersion)"
+      TargetKind="$(ILRepackTargetKind)"
+
+      InputAssemblies="@(_MainAssembly);@(_InputAssemblies)"
+      InternalizeExclude="@(_DoNotInternalizeAssemblies)"
+      FilterAssemblies="@(_FilterAssemblies)"
+      LibraryPaths="@(_LibraryPaths)"
+
+      OutputFile="@(ILRepackOutputFile)"
+      LogFile="@(ILRepackLogFile)"
+    />
+
+  </Target>
+
 </Project>

--- a/Tests/Repack.Lib.RefOnly.Test/ILRepack.Config.props
+++ b/Tests/Repack.Lib.RefOnly.Test/ILRepack.Config.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <ILRepackTarget>false</ILRepackTarget>
+  </PropertyGroup>
+
+</Project>

--- a/Tests/Repack.Lib.RefOnly.Test/Repack.Lib.RefOnly.Test.csproj
+++ b/Tests/Repack.Lib.RefOnly.Test/Repack.Lib.RefOnly.Test.csproj
@@ -47,6 +47,8 @@
   </ItemGroup>
 
 
+  <Import Project="ILRepack.Config.props" />
+  <Import Project="..\..\ILRepack.Lib.MSBuild.Task\build\KageKirin.ILRepack.Lib.MSBuild.Task.props" />
   <Import Project="..\..\ILRepack.Lib.MSBuild.Task\build\KageKirin.ILRepack.Lib.MSBuild.Task.targets" />
   <Import Project="ILRepack.targets" />
 

--- a/Tests/Repack.Lib.Target.Test/ILRepack.Config.props
+++ b/Tests/Repack.Lib.Target.Test/ILRepack.Config.props
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <ILRepackTarget>true</ILRepackTarget>
+    <ILRepackIncludeReferenceAssemblies>true</ILRepackIncludeReferenceAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ILRepackFilterAssemblies Include="TestLibA" />
+    <ILRepackFilterAssemblies Include="xunit" />
+
+    <ILRepackInternalizeExclude Include="Mono.Cecil.TypeSystem" />
+    <ILRepackInternalizeExclude Include="Microsoft.Win32" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Repack.Lib.Target.Test/Repack.Lib.Target.Test.csproj
+++ b/Tests/Repack.Lib.Target.Test/Repack.Lib.Target.Test.csproj
@@ -1,0 +1,50 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Repack.Lib.Target.Test</RootNamespace>
+    <TargetFramework>net9.0</TargetFramework>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <!--
+    To enable the Microsoft Testing Platform 'dotnet test' experience, add property:
+      <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+
+    To enable the Microsoft Testing Platform native command line experience, add property:
+      <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+
+    For more information on Microsoft Testing Platform support in xUnit.net, please visit:
+      https://xunit.net/docs/getting-started/v3/microsoft-testing-platform
+    -->
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" PrivateAssets="all" />
+    <PackageReference Include="xunit.v3" PrivateAssets="all" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TestLibA\TestLibA.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\..\ILRepack.Lib.MSBuild.Task\ILRepack.Lib.MSBuild.Task.csproj" PrivateAssets="all" IncludeAssets="all" />
+  </ItemGroup>
+
+
+  <Import Project="ILRepack.Config.props" />
+  <Import Project="..\..\ILRepack.Lib.MSBuild.Task\build\KageKirin.ILRepack.Lib.MSBuild.Task.props" />
+  <Import Project="..\..\ILRepack.Lib.MSBuild.Task\build\KageKirin.ILRepack.Lib.MSBuild.Task.targets" />
+
+</Project>

--- a/Tests/Repack.Lib.Target.Test/TestLibATest.cs
+++ b/Tests/Repack.Lib.Target.Test/TestLibATest.cs
@@ -1,0 +1,13 @@
+using TestLibA;
+
+namespace Repack.Tool.Test;
+
+public class TestLibATest
+{
+    [Fact]
+    public void SampleA()
+    {
+        SampleA sampleA = new();
+        Assert.Equal(1, sampleA.PerformWork());
+    }
+}

--- a/Tests/Repack.Lib.Target.Test/xunit.runner.json
+++ b/Tests/Repack.Lib.Target.Test/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}

--- a/Tests/Repack.Lib.Test/ILRepack.Config.props
+++ b/Tests/Repack.Lib.Test/ILRepack.Config.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <ILRepackTarget>false</ILRepackTarget>
+  </PropertyGroup>
+
+</Project>

--- a/Tests/Repack.Lib.Test/Repack.Lib.Test.csproj
+++ b/Tests/Repack.Lib.Test/Repack.Lib.Test.csproj
@@ -42,7 +42,8 @@
     <ProjectReference Include="..\..\ILRepack.Lib.MSBuild.Task\ILRepack.Lib.MSBuild.Task.csproj" PrivateAssets="all" IncludeAssets="all" />
   </ItemGroup>
 
-
+  <Import Project="ILRepack.Config.props" />
+  <Import Project="..\..\ILRepack.Lib.MSBuild.Task\build\KageKirin.ILRepack.Lib.MSBuild.Task.props" />
   <Import Project="..\..\ILRepack.Lib.MSBuild.Task\build\KageKirin.ILRepack.Lib.MSBuild.Task.targets" />
   <Import Project="ILRepack.targets" />
 

--- a/Tests/Repack.Tool.RefOnly.Test/ILRepack.Config.props
+++ b/Tests/Repack.Tool.RefOnly.Test/ILRepack.Config.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <ILRepackTarget>false</ILRepackTarget>
+  </PropertyGroup>
+
+</Project>

--- a/Tests/Repack.Tool.RefOnly.Test/Repack.Tool.RefOnly.Test.csproj
+++ b/Tests/Repack.Tool.RefOnly.Test/Repack.Tool.RefOnly.Test.csproj
@@ -47,6 +47,8 @@
   </ItemGroup>
 
 
+  <Import Project="ILRepack.Config.props" />
+  <Import Project="..\..\ILRepack.Lib.MSBuild.Task\build\KageKirin.ILRepack.Lib.MSBuild.Task.props" />
   <Import Project="..\..\ILRepack.Tool.MSBuild.Task\build\KageKirin.ILRepack.Tool.MSBuild.Task.targets" />
   <Import Project="ILRepack.targets" />
 

--- a/Tests/Repack.Tool.Target.Test/ILRepack.Config.props
+++ b/Tests/Repack.Tool.Target.Test/ILRepack.Config.props
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <ILRepackTarget>true</ILRepackTarget>
+    <ILRepackIncludeReferenceAssemblies>true</ILRepackIncludeReferenceAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ILRepackFilterAssemblies Include="TestLibA" />
+    <ILRepackFilterAssemblies Include="xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Repack.Tool.Target.Test/Repack.Tool.Target.Test.csproj
+++ b/Tests/Repack.Tool.Target.Test/Repack.Tool.Target.Test.csproj
@@ -1,0 +1,50 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Repack.Tool.Target.Test</RootNamespace>
+    <TargetFramework>net9.0</TargetFramework>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <!--
+    To enable the Microsoft Testing Platform 'dotnet test' experience, add property:
+      <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+
+    To enable the Microsoft Testing Platform native command line experience, add property:
+      <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+
+    For more information on Microsoft Testing Platform support in xUnit.net, please visit:
+      https://xunit.net/docs/getting-started/v3/microsoft-testing-platform
+    -->
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" PrivateAssets="all" />
+    <PackageReference Include="xunit.v3" PrivateAssets="all" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TestLibA\TestLibA.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\..\ILRepack.Tool.MSBuild.Task\ILRepack.Tool.MSBuild.Task.csproj" PrivateAssets="all" IncludeAssets="all" />
+  </ItemGroup>
+
+
+  <Import Project="ILRepack.Config.props" />
+  <Import Project="..\..\ILRepack.Tool.MSBuild.Task\build\KageKirin.ILRepack.Tool.MSBuild.Task.props" />
+  <Import Project="..\..\ILRepack.Tool.MSBuild.Task\build\KageKirin.ILRepack.Tool.MSBuild.Task.targets" />
+
+</Project>

--- a/Tests/Repack.Tool.Target.Test/TestLibATest.cs
+++ b/Tests/Repack.Tool.Target.Test/TestLibATest.cs
@@ -1,0 +1,13 @@
+using TestLibA;
+
+namespace Repack.Tool.Test;
+
+public class TestLibATest
+{
+    [Fact]
+    public void SampleA()
+    {
+        SampleA sampleA = new();
+        Assert.Equal(1, sampleA.PerformWork());
+    }
+}

--- a/Tests/Repack.Tool.Target.Test/xunit.runner.json
+++ b/Tests/Repack.Tool.Target.Test/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}

--- a/Tests/Repack.Tool.Test/ILRepack.Config.props
+++ b/Tests/Repack.Tool.Test/ILRepack.Config.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <ILRepackTarget>false</ILRepackTarget>
+  </PropertyGroup>
+
+</Project>

--- a/Tests/Repack.Tool.Test/Repack.Tool.Test.csproj
+++ b/Tests/Repack.Tool.Test/Repack.Tool.Test.csproj
@@ -43,6 +43,8 @@
   </ItemGroup>
 
 
+  <Import Project="ILRepack.Config.props" />
+  <Import Project="..\..\ILRepack.Lib.MSBuild.Task\build\KageKirin.ILRepack.Lib.MSBuild.Task.props" />
   <Import Project="..\..\ILRepack.Tool.MSBuild.Task\build\KageKirin.ILRepack.Tool.MSBuild.Task.targets" />
   <Import Project="ILRepack.targets" />
 


### PR DESCRIPTION
- **build: define property defaults for ILRepack.Tool.MSBuild.Task**
- **build: define property defaults for ILRepack.Lib.MSBuild.Task**
- **build: include props file in ILRepack.Tool.MSBuild.Task package**
- **build: include props file in ILRepack.Lib.MSBuild.Task package**
- **build: define default target for ILRepack.Tool.MSBuild.Task**
- **build: define default target for ILRepack.Lib.MSBuild.Task**
- **feat: add Repack.Tool.Target.Test unit test project**
- **feat: add Repack.Lib.Target.Test unit test project**
- **build: exclude Microsoft.Build.Utilities.Core from being repacked into ILRepack.Lib.MSBuild.Task**
- **build: exclude Microsoft.Build.Framework from being repacked into ILRepack.Lib.MSBuild.Task**
- **build: define ILRepack properties for Repack.Lib.RefOnly.Test**
- **build: define ILRepack properties for Repack.Lib.Test**
- **build: define ILRepack properties for Repack.Tool.RefOnly.Test**
- **build: define ILRepack properties for Repack.Tool.Test**
