### PR TITLE
build: exclude Mono.Cecil from being repacked into ILRepack.Lib.MSBuild.Task

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepack.not
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.not
@@ -2,3 +2,4 @@ Microsoft.Win32
 System
 System.IO
 Microsoft.Build
+Mono.Cecil

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.targets
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="ILRepackerExe" AfterTargets="Compile" DependsOnTargets="ResolveAssemblyReferences">
+  <Target Name="ILRepackerExeForILRepackLibMSBuildTask" AfterTargets="Compile" DependsOnTargets="ResolveAssemblyReferences">
 
     <Message Text="Repacking $(IntermediateOutputPath)" Importance="high" />
     <PropertyGroup>


### PR DESCRIPTION
- **build: exclude Mono.Cecil from being repacked into ILRepack.Lib.MSBuild.Task**
- **build: change ILRepack target name to ILRepackerExeForILRepackLibMSBuildTask**
