### PR TITLE
refactor: mark input and output assembly properties as required

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -63,6 +63,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual string Version { get; set; } = string.Empty;
 
+    [Required]
     public virtual Microsoft.Build.Framework.ITaskItem[] InputAssemblies { get; set; } = [];
 
     public virtual Microsoft.Build.Framework.ITaskItem[] LibraryPaths { get; set; } = [];

--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -70,6 +70,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual Microsoft.Build.Framework.ITaskItem[] InternalizeExclude { get; set; } = [];
 
+    [Required]
     public virtual Microsoft.Build.Framework.ITaskItem OutputFile { get; set; } = default;
 
     public virtual Microsoft.Build.Framework.ITaskItem LogFile { get; set; } = default;

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -60,6 +60,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual string Version { get; set; } = string.Empty;
 
+    [Required]
     public virtual Microsoft.Build.Framework.ITaskItem[] InputAssemblies { get; set; } = [];
 
     public virtual Microsoft.Build.Framework.ITaskItem[] LibraryPaths { get; set; } = [];

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -67,6 +67,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual Microsoft.Build.Framework.ITaskItem[] InternalizeExclude { get; set; } = [];
 
+    [Required]
     public virtual Microsoft.Build.Framework.ITaskItem OutputFile { get; set; } = default;
 
     public virtual Microsoft.Build.Framework.ITaskItem LogFile { get; set; } = default;


### PR DESCRIPTION
- **refactor: mark property `ILRepack.InputAssemblies` as required**
- **refactor: mark property `ILRepack.OutputFile` as required**
