### PR TITLE
fix: add missing lib paths used for repacking ILRepack.Lib.MSBuild.Task

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="all" />
     <PackageReference Include="ILRepack" PrivateAssets="all" IncludeAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="ILRepack.Lib" PrivateAssets="all" IncludeAssets="all" GeneratePathProperty="true" />

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="ILRepack" PrivateAssets="all" IncludeAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="ILRepack.Lib" PrivateAssets="all" IncludeAssets="all" GeneratePathProperty="true" />
   </ItemGroup>

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.targets
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.targets
@@ -6,9 +6,10 @@
     <PropertyGroup>
       <_ThisAssembly>$(IntermediateOutputPath)$(TargetFileName)</_ThisAssembly>
       <_ILRepackAssembly>$(PkgILRepack_Lib)/lib/net472/ILRepack.dll</_ILRepackAssembly>
+      <_ILRepackLibs>/lib:$(PkgMicrosoft_Build_Utilities_Core)\lib\net472 /lib:$(PkgMicrosoft_Build_Framework)\lib\net472</_ILRepackLibs>
       <_ILRepackExclude>ILRepack.not</_ILRepackExclude>
       <_ILRepackExe>$(PkgILRepack)/tools/ILRepack.exe</_ILRepackExe>
-      <_ILRepackCmd>$(_ILRepackExe) /internalize:$(_ILRepackExclude) /renameinternalized /log:$(_ThisAssembly).ilrepack.log /out:$(_ThisAssembly).repack $(_ThisAssembly) $(_ILRepackAssembly)</_ILRepackCmd>
+      <_ILRepackCmd>$(_ILRepackExe) /internalize:$(_ILRepackExclude) /renameinternalized $(_ILRepackLibs) /log:$(_ThisAssembly).ilrepack.log /out:$(_ThisAssembly).repack $(_ThisAssembly) $(_ILRepackAssembly)</_ILRepackCmd>
     </PropertyGroup>
 
     <Message Text="running: $(_ILRepackCmd)" Importance="high" />


### PR DESCRIPTION
- **build: generate path property for Microsoft.Build.Utilities.Core**
- **build: generate path property for Microsoft.Build.Framework**
- **build: add `/lib` arguments to Microsoft.Build.Utilities.Core and Microsoft.Build.Framework to ILRepack step**
