### PR TITLE
fix: pass `$(LibraryPaths)` to ILRepack tasks

### DIFF
--- a/Tests/Repack.Lib.RefOnly.Test/ILRepack.targets
+++ b/Tests/Repack.Lib.RefOnly.Test/ILRepack.targets
@@ -13,7 +13,7 @@
       <FilterAssemblies Include="TestLibA" />
       <FilterAssemblies Include="xunit" />
 
-      <LibraryPath Include="%(InputAssemblies.Directory)" />
+      <LibraryPaths Include="%(InputAssemblies.Directory)" />
     </ItemGroup>
 
     <ItemGroup>
@@ -31,6 +31,7 @@
       InputAssemblies="@(MainAssembly);@(InputAssemblies)"
       InternalizeExclude="@(DoNotInternalizeAssemblies)"
       FilterAssemblies="@(FilterAssemblies)"
+      LibraryPaths="@(LibraryPaths)"
       Timeout="60"
 
       OutputFile="@(MainAssembly)"

--- a/Tests/Repack.Lib.Test/ILRepack.targets
+++ b/Tests/Repack.Lib.Test/ILRepack.targets
@@ -13,7 +13,7 @@
       <FilterAssemblies Include="TestLibA" />
       <FilterAssemblies Include="xunit" />
 
-      <LibraryPath Include="%(InputAssemblies.Directory)" />
+      <LibraryPaths Include="%(InputAssemblies.Directory)" />
     </ItemGroup>
 
     <ItemGroup>
@@ -31,6 +31,7 @@
       InputAssemblies="@(MainAssembly);@(InputAssemblies)"
       InternalizeExclude="@(DoNotInternalizeAssemblies)"
       FilterAssemblies="@(FilterAssemblies)"
+      LibraryPaths="@(LibraryPaths)"
       Timeout="60"
 
       OutputFile="@(MainAssembly)"

--- a/Tests/Repack.Tool.RefOnly.Test/ILRepack.targets
+++ b/Tests/Repack.Tool.RefOnly.Test/ILRepack.targets
@@ -13,7 +13,7 @@
       <FilterAssemblies Include="TestLibA" />
       <FilterAssemblies Include="xunit" />
 
-      <LibraryPath Include="%(InputAssemblies.Directory)" />
+      <LibraryPaths Include="%(InputAssemblies.Directory)" />
     </ItemGroup>
 
     <ItemGroup>
@@ -31,6 +31,7 @@
       InputAssemblies="@(MainAssembly);@(InputAssemblies)"
       InternalizeExclude="@(DoNotInternalizeAssemblies)"
       FilterAssemblies="@(FilterAssemblies)"
+      LibraryPaths="@(LibraryPaths)"
       Timeout="60"
 
       OutputFile="@(MainAssembly)"

--- a/Tests/Repack.Tool.Test/ILRepack.targets
+++ b/Tests/Repack.Tool.Test/ILRepack.targets
@@ -13,7 +13,7 @@
       <FilterAssemblies Include="TestLibA" />
       <FilterAssemblies Include="xunit" />
 
-      <LibraryPath Include="%(InputAssemblies.Directory)" />
+      <LibraryPaths Include="%(InputAssemblies.Directory)" />
     </ItemGroup>
 
     <ItemGroup>
@@ -31,6 +31,7 @@
       InputAssemblies="@(MainAssembly);@(InputAssemblies)"
       InternalizeExclude="@(DoNotInternalizeAssemblies)"
       FilterAssemblies="@(FilterAssemblies)"
+      LibraryPaths="@(LibraryPaths)"
       Timeout="60"
 
       OutputFile="@(MainAssembly)"


### PR DESCRIPTION
- **fix: pass `$(LibraryPaths)` to ILRepack task in Repack.Tool.Test project**
- **fix: pass `$(LibraryPaths)` to ILRepack task in Repack.Lib.Test project**
- **fix: pass `$(LibraryPaths)` to ILRepack task in Repack.Tool.RefOnly.Test project**
- **fix: pass `$(LibraryPaths)` to ILRepack task in Repack.Lib.RefOnly.Test project**
