### PR TITLE
fix: exclude Microsoft.Build assemblies from being repacked into ILRepack.Lib.MSBuild.Task

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepack.not
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.not
@@ -2,4 +2,5 @@ Microsoft.Win32
 System
 System.IO
 Microsoft.Build
+Microsoft.Build.Framework
 Mono.Cecil

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.not
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.not
@@ -3,4 +3,5 @@ System
 System.IO
 Microsoft.Build
 Microsoft.Build.Framework
+Microsoft.Build.Utilities.Core
 Mono.Cecil


### PR DESCRIPTION
- **build: exclude Microsoft.Build.Framework from being repacked into ILRepack.Lib.MSBuild.Task**
- **build: exclude Microsoft.Build.Utilities.Core from being repacked into ILRepack.Lib.MSBuild.Task**
