### PR TITLE
build: pass `@(ILRepackLibraryPaths)` to internal variable as-is

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -46,7 +46,7 @@
       <_FilterAssemblies Include="$(AssemblyName)" />
       <_FilterAssemblies Include="@(ILRepackFilterAssemblies)" />
 
-      <_LibraryPaths Include="%(ILRepackLibraryPaths.Directory)" />
+      <_LibraryPaths Include="@(ILRepackLibraryPaths)" />
       <_LibraryPaths Include="%(_InputAssemblies.Directory)" />
     </ItemGroup>
 

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -46,7 +46,7 @@
       <_FilterAssemblies Include="$(AssemblyName)" />
       <_FilterAssemblies Include="@(ILRepackFilterAssemblies)" />
 
-      <_LibraryPaths Include="%(ILRepackLibraryPaths.Directory)" />
+      <_LibraryPaths Include="@(ILRepackLibraryPaths)" />
       <_LibraryPaths Include="%(_InputAssemblies.Directory)" />
     </ItemGroup>
 


### PR DESCRIPTION
note: was passed as `%(ILRepackLibraryPaths.Directory)` but this is not needed here,
      as this would select the parent directory to the library directory,
      which is causing errors
