### PR TITLE
build: correctly pass `@(ILRepackInternalizeExclude)` items to ILRepack task

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -51,6 +51,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <_DoNotInternalizeAssemblies Include="@(ILRepackInternalizeExclude)" />
     </ItemGroup>
 
     <Message Text="Repacking assemblies in $(IntermediateOutputPath): @(_InputAssemblies->'%(Identity)', ' ') into @(_MainAssembly->'%(Identity)')" Importance="high" />

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -51,6 +51,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <_DoNotInternalizeAssemblies Include="@(ILRepackInternalizeExclude)" />
     </ItemGroup>
 
     <Message Text="Repacking assemblies in $(IntermediateOutputPath): @(_InputAssemblies->'%(Identity)', ' ') into @(_MainAssembly->'%(Identity)')" Importance="high" />


### PR DESCRIPTION
- **build: remove `@(_MainAssembly)` from list of not internalized assemblies**
- **build: pass `@(ILRepackInternalizeExclude)` to parameter `ILRepack.InternalizeExclude`**
