### PR TITLE
fix: write `InternalizeExclude` items as assembly name only, removing path

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -200,7 +200,13 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
             );
 
             foreach (var asm in InternalizeExclude)
-                writer.WriteLine(asm.ItemSpec);
+            {
+                writer.WriteLine(
+                    asm.ItemSpec.EndsWith(".dll")
+                        ? Path.GetFileNameWithoutExtension(asm.ItemSpec)
+                        : Path.GetFileName(asm.ItemSpec)
+                );
+            }
 
             repackOptions.ExcludeFile = excludeFile;
         }

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -204,7 +204,13 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
             );
 
             foreach (var asm in InternalizeExclude)
-                writer.WriteLine(asm.ItemSpec);
+            {
+                writer.WriteLine(
+                    asm.ItemSpec.EndsWith(".dll")
+                        ? Path.GetFileNameWithoutExtension(asm.ItemSpec)
+                        : Path.GetFileName(asm.ItemSpec)
+                );
+            }
 
             cmdParams.Add($"/internalize:\"{excludeFile}\"");
         }


### PR DESCRIPTION
reason: the Exclude file requires the assembly names without extension nor path.
