### PR TITLE
refactor: rename ILRepack task properties to their RepackOptions equivalent

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -19,7 +19,7 @@ namespace KageKirin.ILRepack.Lib.MSBuild.Task;
 
 public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 {
-    public virtual bool AllowDup { get; set; }
+    public virtual bool AllowAllDuplicateTypes { get; set; }
 
     public virtual bool AllowDuplicateResources { get; set; }
 
@@ -125,7 +125,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
         RepackOptions repackOptions = new()
         {
-            AllowAllDuplicateTypes = AllowDup,
+            AllowAllDuplicateTypes = AllowAllDuplicateTypes,
             AllowDuplicateResources = AllowDuplicateResources,
             AllowMultipleAssemblyLevelAttributes = AllowMultiple,
             AllowWildCards = Wildcards,

--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -57,7 +57,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual bool XmlDocumentation { get; set; }
 
-    public virtual bool ZeroPEKind { get; set; }
+    public virtual bool AllowZeroPeKind { get; set; }
 
     public virtual string TargetKind { get; set; } = string.Empty;
 
@@ -129,7 +129,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
             AllowDuplicateResources = AllowDuplicateResources,
             AllowMultipleAssemblyLevelAttributes = AllowMultipleAssemblyLevelAttributes,
             AllowWildCards = AllowWildCards,
-            AllowZeroPeKind = ZeroPEKind,
+            AllowZeroPeKind = AllowZeroPeKind,
             CopyAttributes = CopyAttributes,
             DebugInfo = DebugInfo,
             DelaySign = DelaySign,

--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -23,7 +23,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual bool AllowDuplicateResources { get; set; }
 
-    public virtual bool AllowMultiple { get; set; }
+    public virtual bool AllowMultipleAssemblyLevelAttributes { get; set; }
 
     public virtual bool CopyAttrs { get; set; }
 
@@ -127,7 +127,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
         {
             AllowAllDuplicateTypes = AllowAllDuplicateTypes,
             AllowDuplicateResources = AllowDuplicateResources,
-            AllowMultipleAssemblyLevelAttributes = AllowMultiple,
+            AllowMultipleAssemblyLevelAttributes = AllowMultipleAssemblyLevelAttributes,
             AllowWildCards = Wildcards,
             AllowZeroPeKind = ZeroPEKind,
             CopyAttributes = CopyAttrs,

--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -33,7 +33,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual bool ExcludeInternalizeSerializable { get; set; }
 
-    public virtual bool ILLink { get; set; }
+    public virtual bool MergeIlLinkerFiles { get; set; }
 
     public virtual bool Internalize { get; set; }
 
@@ -137,7 +137,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
             Internalize = Internalize,
             KeepOtherVersionReferences = KeepOtherVersionReferences,
             LogVerbose = Verbose,
-            MergeIlLinkerFiles = ILLink,
+            MergeIlLinkerFiles = MergeIlLinkerFiles,
             NoRepackRes = NoRepackRes,
             Parallel = Parallel,
             PreserveTimestamp = PreserveTimestamp,

--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -53,7 +53,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual bool LogVerbose { get; set; }
 
-    public virtual bool Wildcards { get; set; }
+    public virtual bool AllowWildCards { get; set; }
 
     public virtual bool XmlDocs { get; set; }
 
@@ -128,7 +128,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
             AllowAllDuplicateTypes = AllowAllDuplicateTypes,
             AllowDuplicateResources = AllowDuplicateResources,
             AllowMultipleAssemblyLevelAttributes = AllowMultipleAssemblyLevelAttributes,
-            AllowWildCards = Wildcards,
+            AllowWildCards = AllowWildCards,
             AllowZeroPeKind = ZeroPEKind,
             CopyAttributes = CopyAttributes,
             DebugInfo = DebugInfo,

--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -51,7 +51,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual bool UnionMerge { get; set; }
 
-    public virtual bool Verbose { get; set; }
+    public virtual bool LogVerbose { get; set; }
 
     public virtual bool Wildcards { get; set; }
 
@@ -136,7 +136,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
             ExcludeInternalizeSerializable = ExcludeInternalizeSerializable,
             Internalize = Internalize,
             KeepOtherVersionReferences = KeepOtherVersionReferences,
-            LogVerbose = Verbose,
+            LogVerbose = LogVerbose,
             MergeIlLinkerFiles = MergeIlLinkerFiles,
             NoRepackRes = NoRepackRes,
             Parallel = Parallel,

--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -25,7 +25,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual bool AllowMultipleAssemblyLevelAttributes { get; set; }
 
-    public virtual bool CopyAttrs { get; set; }
+    public virtual bool CopyAttributes { get; set; }
 
     public virtual bool DebugInfo { get; set; }
 
@@ -130,7 +130,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
             AllowMultipleAssemblyLevelAttributes = AllowMultipleAssemblyLevelAttributes,
             AllowWildCards = Wildcards,
             AllowZeroPeKind = ZeroPEKind,
-            CopyAttributes = CopyAttrs,
+            CopyAttributes = CopyAttributes,
             DebugInfo = DebugInfo,
             DelaySign = DelaySign,
             ExcludeInternalizeSerializable = ExcludeInternalizeSerializable,

--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -49,7 +49,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual bool SkipConfigMerge { get; set; }
 
-    public virtual bool Union { get; set; }
+    public virtual bool UnionMerge { get; set; }
 
     public virtual bool Verbose { get; set; }
 
@@ -143,7 +143,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
             PreserveTimestamp = PreserveTimestamp,
             RenameInternalized = RenameInternalized,
             SkipConfigMerge = SkipConfigMerge,
-            UnionMerge = Union,
+            UnionMerge = UnionMerge,
             XmlDocumentation = XmlDocs,
         };
 

--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -55,7 +55,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual bool AllowWildCards { get; set; }
 
-    public virtual bool XmlDocs { get; set; }
+    public virtual bool XmlDocumentation { get; set; }
 
     public virtual bool ZeroPEKind { get; set; }
 
@@ -144,7 +144,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
             RenameInternalized = RenameInternalized,
             SkipConfigMerge = SkipConfigMerge,
             UnionMerge = UnionMerge,
-            XmlDocumentation = XmlDocs,
+            XmlDocumentation = XmlDocumentation,
         };
 
         if (!string.IsNullOrWhiteSpace(TargetKind))

--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -47,7 +47,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual bool RenameInternalized { get; set; }
 
-    public virtual bool SkipConfig { get; set; }
+    public virtual bool SkipConfigMerge { get; set; }
 
     public virtual bool Union { get; set; }
 
@@ -142,7 +142,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
             Parallel = Parallel,
             PreserveTimestamp = PreserveTimestamp,
             RenameInternalized = RenameInternalized,
-            SkipConfigMerge = SkipConfig,
+            SkipConfigMerge = SkipConfigMerge,
             UnionMerge = Union,
             XmlDocumentation = XmlDocs,
         };

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
@@ -58,9 +58,9 @@
     <ILRepackCopyAttrs Condition="'$(ILRepackCopyAttrs)' == 'disable'">false</ILRepackCopyAttrs>
     <ILRepackCopyAttrs Condition="'$(ILRepackCopyAttrs)' == 'enable'">true</ILRepackCopyAttrs>
 
-    <ILRepackAllowMultiple Condition="'$(ILRepackAllowMultiple)' == ''">false</ILRepackAllowMultiple>
-    <ILRepackAllowMultiple Condition="'$(ILRepackAllowMultiple)' == 'disable'">false</ILRepackAllowMultiple>
-    <ILRepackAllowMultiple Condition="'$(ILRepackAllowMultiple)' == 'enable'">true</ILRepackAllowMultiple>
+    <ILRepackAllowMultipleAssemblyLevelAttributes Condition="'$(ILRepackAllowMultipleAssemblyLevelAttributes)' == ''">false</ILRepackAllowMultipleAssemblyLevelAttributes>
+    <ILRepackAllowMultipleAssemblyLevelAttributes Condition="'$(ILRepackAllowMultipleAssemblyLevelAttributes)' == 'disable'">false</ILRepackAllowMultipleAssemblyLevelAttributes>
+    <ILRepackAllowMultipleAssemblyLevelAttributes Condition="'$(ILRepackAllowMultipleAssemblyLevelAttributes)' == 'enable'">true</ILRepackAllowMultipleAssemblyLevelAttributes>
 
     <ILRepackKeepOtherVersionReferences Condition="'$(ILRepackKeepOtherVersionReferences)' == ''">false</ILRepackKeepOtherVersionReferences>
     <ILRepackKeepOtherVersionReferences Condition="'$(ILRepackKeepOtherVersionReferences)' == 'disable'">false</ILRepackKeepOtherVersionReferences>

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
@@ -82,9 +82,9 @@
     <ILRepackXmlDocumentation Condition="'$(ILRepackXmlDocumentation)' == 'disable'">false</ILRepackXmlDocumentation>
     <ILRepackXmlDocumentation Condition="'$(ILRepackXmlDocumentation)' == 'enable'">true</ILRepackXmlDocumentation>
 
-    <ILRepackZeroPEKind Condition="'$(ILRepackZeroPEKind)' == ''">false</ILRepackZeroPEKind>
-    <ILRepackZeroPEKind Condition="'$(ILRepackZeroPEKind)' == 'disable'">false</ILRepackZeroPEKind>
-    <ILRepackZeroPEKind Condition="'$(ILRepackZeroPEKind)' == 'enable'">true</ILRepackZeroPEKind>
+    <ILRepackAllowZeroPeKind Condition="'$(ILRepackAllowZeroPeKind)' == ''">false</ILRepackAllowZeroPeKind>
+    <ILRepackAllowZeroPeKind Condition="'$(ILRepackAllowZeroPeKind)' == 'disable'">false</ILRepackAllowZeroPeKind>
+    <ILRepackAllowZeroPeKind Condition="'$(ILRepackAllowZeroPeKind)' == 'enable'">true</ILRepackAllowZeroPeKind>
 
     <ILRepackTimeout Condition="'$(ILRepackTimeout)' == ''">30</ILRepackTimeout>
     <ILRepackTimeout Condition="$([System.Int32]::TryParse('$(ILRepackTimeout)', null))">30</ILRepackTimeout>

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
@@ -78,9 +78,9 @@
     <ILRepackMergeIlLinkerFiles Condition="'$(ILRepackMergeIlLinkerFiles)' == 'disable'">false</ILRepackMergeIlLinkerFiles>
     <ILRepackMergeIlLinkerFiles Condition="'$(ILRepackMergeIlLinkerFiles)' == 'enable'">true</ILRepackMergeIlLinkerFiles>
 
-    <ILRepackXmlDocs Condition="'$(ILRepackXmlDocs)' == ''">false</ILRepackXmlDocs>
-    <ILRepackXmlDocs Condition="'$(ILRepackXmlDocs)' == 'disable'">false</ILRepackXmlDocs>
-    <ILRepackXmlDocs Condition="'$(ILRepackXmlDocs)' == 'enable'">true</ILRepackXmlDocs>
+    <ILRepackXmlDocumentation Condition="'$(ILRepackXmlDocumentation)' == ''">false</ILRepackXmlDocumentation>
+    <ILRepackXmlDocumentation Condition="'$(ILRepackXmlDocumentation)' == 'disable'">false</ILRepackXmlDocumentation>
+    <ILRepackXmlDocumentation Condition="'$(ILRepackXmlDocumentation)' == 'enable'">true</ILRepackXmlDocumentation>
 
     <ILRepackZeroPEKind Condition="'$(ILRepackZeroPEKind)' == ''">false</ILRepackZeroPEKind>
     <ILRepackZeroPEKind Condition="'$(ILRepackZeroPEKind)' == 'disable'">false</ILRepackZeroPEKind>

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
@@ -74,9 +74,9 @@
     <ILRepackSkipConfig Condition="'$(ILRepackSkipConfig)' == 'disable'">false</ILRepackSkipConfig>
     <ILRepackSkipConfig Condition="'$(ILRepackSkipConfig)' == 'enable'">true</ILRepackSkipConfig>
 
-    <ILRepackILLink Condition="'$(ILRepackILLink)' == ''">false</ILRepackILLink>
-    <ILRepackILLink Condition="'$(ILRepackILLink)' == 'disable'">false</ILRepackILLink>
-    <ILRepackILLink Condition="'$(ILRepackILLink)' == 'enable'">true</ILRepackILLink>
+    <ILRepackMergeIlLinkerFiles Condition="'$(ILRepackMergeIlLinkerFiles)' == ''">false</ILRepackMergeIlLinkerFiles>
+    <ILRepackMergeIlLinkerFiles Condition="'$(ILRepackMergeIlLinkerFiles)' == 'disable'">false</ILRepackMergeIlLinkerFiles>
+    <ILRepackMergeIlLinkerFiles Condition="'$(ILRepackMergeIlLinkerFiles)' == 'enable'">true</ILRepackMergeIlLinkerFiles>
 
     <ILRepackXmlDocs Condition="'$(ILRepackXmlDocs)' == ''">false</ILRepackXmlDocs>
     <ILRepackXmlDocs Condition="'$(ILRepackXmlDocs)' == 'disable'">false</ILRepackXmlDocs>

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
@@ -54,9 +54,9 @@
     <ILRepackNoRepackRes Condition="'$(ILRepackNoRepackRes)' == 'disable'">false</ILRepackNoRepackRes>
     <ILRepackNoRepackRes Condition="'$(ILRepackNoRepackRes)' == 'enable'">true</ILRepackNoRepackRes>
 
-    <ILRepackCopyAttrs Condition="'$(ILRepackCopyAttrs)' == ''">false</ILRepackCopyAttrs>
-    <ILRepackCopyAttrs Condition="'$(ILRepackCopyAttrs)' == 'disable'">false</ILRepackCopyAttrs>
-    <ILRepackCopyAttrs Condition="'$(ILRepackCopyAttrs)' == 'enable'">true</ILRepackCopyAttrs>
+    <ILRepackCopyAttributes Condition="'$(ILRepackCopyAttributes)' == ''">false</ILRepackCopyAttributes>
+    <ILRepackCopyAttributes Condition="'$(ILRepackCopyAttributes)' == 'disable'">false</ILRepackCopyAttributes>
+    <ILRepackCopyAttributes Condition="'$(ILRepackCopyAttributes)' == 'enable'">true</ILRepackCopyAttributes>
 
     <ILRepackAllowMultipleAssemblyLevelAttributes Condition="'$(ILRepackAllowMultipleAssemblyLevelAttributes)' == ''">false</ILRepackAllowMultipleAssemblyLevelAttributes>
     <ILRepackAllowMultipleAssemblyLevelAttributes Condition="'$(ILRepackAllowMultipleAssemblyLevelAttributes)' == 'disable'">false</ILRepackAllowMultipleAssemblyLevelAttributes>

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
@@ -26,9 +26,9 @@
     <ILRepackRenameInternalized Condition="'$(ILRepackRenameInternalized)' == 'disable'">false</ILRepackRenameInternalized>
     <ILRepackRenameInternalized Condition="'$(ILRepackRenameInternalized)' == 'enable'">true</ILRepackRenameInternalized>
 
-    <ILRepackWildcards Condition="'$(ILRepackWildcards)' == ''">false</ILRepackWildcards>
-    <ILRepackWildcards Condition="'$(ILRepackWildcards)' == 'disable'">false</ILRepackWildcards>
-    <ILRepackWildcards Condition="'$(ILRepackWildcards)' == 'enable'">true</ILRepackWildcards>
+    <ILRepackAllowWildCards Condition="'$(ILRepackAllowWildCards)' == ''">false</ILRepackAllowWildCards>
+    <ILRepackAllowWildCards Condition="'$(ILRepackAllowWildCards)' == 'disable'">false</ILRepackAllowWildCards>
+    <ILRepackAllowWildCards Condition="'$(ILRepackAllowWildCards)' == 'enable'">true</ILRepackAllowWildCards>
 
     <ILRepackDelaySign Condition="'$(ILRepackDelaySign)' == ''">false</ILRepackDelaySign>
     <ILRepackDelaySign Condition="'$(ILRepackDelaySign)' == 'disable'">false</ILRepackDelaySign>

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
@@ -42,9 +42,9 @@
     <ILRepackUnion Condition="'$(ILRepackUnion)' == 'disable'">false</ILRepackUnion>
     <ILRepackUnion Condition="'$(ILRepackUnion)' == 'enable'">true</ILRepackUnion>
 
-    <ILRepackAllowDup Condition="'$(ILRepackAllowDup)' == ''">false</ILRepackAllowDup>
-    <ILRepackAllowDup Condition="'$(ILRepackAllowDup)' == 'disable'">false</ILRepackAllowDup>
-    <ILRepackAllowDup Condition="'$(ILRepackAllowDup)' == 'enable'">true</ILRepackAllowDup>
+    <ILRepackAllowAllDuplicateTypes Condition="'$(ILRepackAllowAllDuplicateTypes)' == ''">false</ILRepackAllowAllDuplicateTypes>
+    <ILRepackAllowAllDuplicateTypes Condition="'$(ILRepackAllowAllDuplicateTypes)' == 'disable'">false</ILRepackAllowAllDuplicateTypes>
+    <ILRepackAllowAllDuplicateTypes Condition="'$(ILRepackAllowAllDuplicateTypes)' == 'enable'">true</ILRepackAllowAllDuplicateTypes>
 
     <ILRepackAllowDuplicateResources Condition="'$(ILRepackAllowDuplicateResources)' == ''">false</ILRepackAllowDuplicateResources>
     <ILRepackAllowDuplicateResources Condition="'$(ILRepackAllowDuplicateResources)' == 'disable'">false</ILRepackAllowDuplicateResources>

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
@@ -38,9 +38,9 @@
     <ILRepackExcludeInternalizeSerializable Condition="'$(ILRepackExcludeInternalizeSerializable)' == 'disable'">false</ILRepackExcludeInternalizeSerializable>
     <ILRepackExcludeInternalizeSerializable Condition="'$(ILRepackExcludeInternalizeSerializable)' == 'enable'">true</ILRepackExcludeInternalizeSerializable>
 
-    <ILRepackUnion Condition="'$(ILRepackUnion)' == ''">false</ILRepackUnion>
-    <ILRepackUnion Condition="'$(ILRepackUnion)' == 'disable'">false</ILRepackUnion>
-    <ILRepackUnion Condition="'$(ILRepackUnion)' == 'enable'">true</ILRepackUnion>
+    <ILRepackUnionMerge Condition="'$(ILRepackUnionMerge)' == ''">false</ILRepackUnionMerge>
+    <ILRepackUnionMerge Condition="'$(ILRepackUnionMerge)' == 'disable'">false</ILRepackUnionMerge>
+    <ILRepackUnionMerge Condition="'$(ILRepackUnionMerge)' == 'enable'">true</ILRepackUnionMerge>
 
     <ILRepackAllowAllDuplicateTypes Condition="'$(ILRepackAllowAllDuplicateTypes)' == ''">false</ILRepackAllowAllDuplicateTypes>
     <ILRepackAllowAllDuplicateTypes Condition="'$(ILRepackAllowAllDuplicateTypes)' == 'disable'">false</ILRepackAllowAllDuplicateTypes>

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
@@ -14,9 +14,9 @@
     <ILRepackDebugInfo Condition="'$(ILRepackDebugInfo)' == 'disable'">false</ILRepackDebugInfo>
     <ILRepackDebugInfo Condition="'$(ILRepackDebugInfo)' == 'enable'">true</ILRepackDebugInfo>
 
-    <ILRepackVerbose Condition="'$(ILRepackVerbose)' == ''">false</ILRepackVerbose>
-    <ILRepackVerbose Condition="'$(ILRepackVerbose)' == 'disable'">false</ILRepackVerbose>
-    <ILRepackVerbose Condition="'$(ILRepackVerbose)' == 'enable'">true</ILRepackVerbose>
+    <ILRepackLogVerbose Condition="'$(ILRepackLogVerbose)' == ''">false</ILRepackLogVerbose>
+    <ILRepackLogVerbose Condition="'$(ILRepackLogVerbose)' == 'disable'">false</ILRepackLogVerbose>
+    <ILRepackLogVerbose Condition="'$(ILRepackLogVerbose)' == 'enable'">true</ILRepackLogVerbose>
 
     <ILRepackInternalize Condition="'$(ILRepackInternalize)' == ''">false</ILRepackInternalize>
     <ILRepackInternalize Condition="'$(ILRepackInternalize)' == 'disable'">false</ILRepackInternalize>

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.props
@@ -70,9 +70,9 @@
     <ILRepackPreserveTimestamp Condition="'$(ILRepackPreserveTimestamp)' == 'disable'">false</ILRepackPreserveTimestamp>
     <ILRepackPreserveTimestamp Condition="'$(ILRepackPreserveTimestamp)' == 'enable'">true</ILRepackPreserveTimestamp>
 
-    <ILRepackSkipConfig Condition="'$(ILRepackSkipConfig)' == ''">false</ILRepackSkipConfig>
-    <ILRepackSkipConfig Condition="'$(ILRepackSkipConfig)' == 'disable'">false</ILRepackSkipConfig>
-    <ILRepackSkipConfig Condition="'$(ILRepackSkipConfig)' == 'enable'">true</ILRepackSkipConfig>
+    <ILRepackSkipConfigMerge Condition="'$(ILRepackSkipConfigMerge)' == ''">false</ILRepackSkipConfigMerge>
+    <ILRepackSkipConfigMerge Condition="'$(ILRepackSkipConfigMerge)' == 'disable'">false</ILRepackSkipConfigMerge>
+    <ILRepackSkipConfigMerge Condition="'$(ILRepackSkipConfigMerge)' == 'enable'">true</ILRepackSkipConfigMerge>
 
     <ILRepackMergeIlLinkerFiles Condition="'$(ILRepackMergeIlLinkerFiles)' == ''">false</ILRepackMergeIlLinkerFiles>
     <ILRepackMergeIlLinkerFiles Condition="'$(ILRepackMergeIlLinkerFiles)' == 'disable'">false</ILRepackMergeIlLinkerFiles>

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -74,7 +74,7 @@
       KeepOtherVersionReferences="$(ILRepackKeepOtherVersionReferences)"
       PreserveTimestamp="$(ILRepackPreserveTimestamp)"
       SkipConfig="$(ILRepackSkipConfig)"
-      ILLink="$(ILRepackILLink)"
+      MergeIlLinkerFiles="$(ILRepackMergeIlLinkerFiles)"
       XmlDocs="$(ILRepackXmlDocs)"
       ZeroPEKind="$(ILRepackZeroPEKind)"
       Timeout="$(ILRepackTimeout)"

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -59,7 +59,7 @@
     <ILRepack
       Parallel="$(ILRepackParallel)"
       DebugInfo="$(ILRepackDebugInfo)"
-      Verbose="$(ILRepackVerbose)"
+      LogVerbose="$(ILRepackLogVerbose)"
       Internalize="$(ILRepackInternalize)"
       RenameInternalized="$(ILRepackRenameInternalized)"
       Wildcards="$(ILRepackWildcards)"

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -73,7 +73,7 @@
       AllowMultipleAssemblyLevelAttributes="$(ILRepackAllowMultipleAssemblyLevelAttributes)"
       KeepOtherVersionReferences="$(ILRepackKeepOtherVersionReferences)"
       PreserveTimestamp="$(ILRepackPreserveTimestamp)"
-      SkipConfig="$(ILRepackSkipConfig)"
+      SkipConfigMerge="$(ILRepackSkipConfigMerge)"
       MergeIlLinkerFiles="$(ILRepackMergeIlLinkerFiles)"
       XmlDocs="$(ILRepackXmlDocs)"
       ZeroPEKind="$(ILRepackZeroPEKind)"

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -65,7 +65,7 @@
       Wildcards="$(ILRepackWildcards)"
       DelaySign="$(ILRepackDelaySign)"
       ExcludeInternalizeSerializable="$(ILRepackExcludeInternalizeSerializable)"
-      Union="$(ILRepackUnion)"
+      UnionMerge="$(ILRepackUnionMerge)"
       AllowAllDuplicateTypes="$(ILRepackAllowAllDuplicateTypes)"
       AllowDuplicateResources="$(ILRepackAllowDuplicateResources)"
       NoRepackRes="$(ILRepackNoRepackRes)"

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -62,7 +62,7 @@
       LogVerbose="$(ILRepackLogVerbose)"
       Internalize="$(ILRepackInternalize)"
       RenameInternalized="$(ILRepackRenameInternalized)"
-      Wildcards="$(ILRepackWildcards)"
+      AllowWildCards="$(ILRepackAllowWildCards)"
       DelaySign="$(ILRepackDelaySign)"
       ExcludeInternalizeSerializable="$(ILRepackExcludeInternalizeSerializable)"
       UnionMerge="$(ILRepackUnionMerge)"

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -75,7 +75,7 @@
       PreserveTimestamp="$(ILRepackPreserveTimestamp)"
       SkipConfigMerge="$(ILRepackSkipConfigMerge)"
       MergeIlLinkerFiles="$(ILRepackMergeIlLinkerFiles)"
-      XmlDocs="$(ILRepackXmlDocs)"
+      XmlDocumentation="$(ILRepackXmlDocumentation)"
       ZeroPEKind="$(ILRepackZeroPEKind)"
       Timeout="$(ILRepackTimeout)"
       Version="$(ILRepackVersion)"

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -76,7 +76,7 @@
       SkipConfigMerge="$(ILRepackSkipConfigMerge)"
       MergeIlLinkerFiles="$(ILRepackMergeIlLinkerFiles)"
       XmlDocumentation="$(ILRepackXmlDocumentation)"
-      ZeroPEKind="$(ILRepackZeroPEKind)"
+      AllowZeroPeKind="$(ILRepackAllowZeroPeKind)"
       Timeout="$(ILRepackTimeout)"
       Version="$(ILRepackVersion)"
       TargetKind="$(ILRepackTargetKind)"

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -70,7 +70,7 @@
       AllowDuplicateResources="$(ILRepackAllowDuplicateResources)"
       NoRepackRes="$(ILRepackNoRepackRes)"
       CopyAttrs="$(ILRepackCopyAttrs)"
-      AllowMultiple="$(ILRepackAllowMultiple)"
+      AllowMultipleAssemblyLevelAttributes="$(ILRepackAllowMultipleAssemblyLevelAttributes)"
       KeepOtherVersionReferences="$(ILRepackKeepOtherVersionReferences)"
       PreserveTimestamp="$(ILRepackPreserveTimestamp)"
       SkipConfig="$(ILRepackSkipConfig)"

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -69,7 +69,7 @@
       AllowAllDuplicateTypes="$(ILRepackAllowAllDuplicateTypes)"
       AllowDuplicateResources="$(ILRepackAllowDuplicateResources)"
       NoRepackRes="$(ILRepackNoRepackRes)"
-      CopyAttrs="$(ILRepackCopyAttrs)"
+      CopyAttributes="$(ILRepackCopyAttributes)"
       AllowMultipleAssemblyLevelAttributes="$(ILRepackAllowMultipleAssemblyLevelAttributes)"
       KeepOtherVersionReferences="$(ILRepackKeepOtherVersionReferences)"
       PreserveTimestamp="$(ILRepackPreserveTimestamp)"

--- a/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/build/KageKirin.ILRepack.Lib.MSBuild.Task.targets
@@ -66,7 +66,7 @@
       DelaySign="$(ILRepackDelaySign)"
       ExcludeInternalizeSerializable="$(ILRepackExcludeInternalizeSerializable)"
       Union="$(ILRepackUnion)"
-      AllowDup="$(ILRepackAllowDup)"
+      AllowAllDuplicateTypes="$(ILRepackAllowAllDuplicateTypes)"
       AllowDuplicateResources="$(ILRepackAllowDuplicateResources)"
       NoRepackRes="$(ILRepackNoRepackRes)"
       CopyAttrs="$(ILRepackCopyAttrs)"

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -48,7 +48,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual bool UnionMerge { get; set; }
 
-    public virtual bool Verbose { get; set; }
+    public virtual bool LogVerbose { get; set; }
 
     public virtual bool Wildcards { get; set; }
 
@@ -145,7 +145,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
         if (UnionMerge)
             cmdParams.Add("/union");
 
-        if (Verbose)
+        if (LogVerbose)
             cmdParams.Add("/verbose");
 
         if (Wildcards)

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -50,7 +50,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual bool LogVerbose { get; set; }
 
-    public virtual bool Wildcards { get; set; }
+    public virtual bool AllowWildCards { get; set; }
 
     public virtual bool XmlDocs { get; set; }
 
@@ -148,7 +148,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
         if (LogVerbose)
             cmdParams.Add("/verbose");
 
-        if (Wildcards)
+        if (AllowWildCards)
             cmdParams.Add("/wildcards");
 
         if (XmlDocs)

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -22,7 +22,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual bool AllowMultipleAssemblyLevelAttributes { get; set; }
 
-    public virtual bool CopyAttrs { get; set; }
+    public virtual bool CopyAttributes { get; set; }
 
     public virtual bool DebugInfo { get; set; }
 
@@ -106,7 +106,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
         if (AllowMultipleAssemblyLevelAttributes)
             cmdParams.Add("/allowMultiple");
 
-        if (CopyAttrs)
+        if (CopyAttributes)
             cmdParams.Add("/copyattrs");
 
         if (!DebugInfo)

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -30,7 +30,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual bool ExcludeInternalizeSerializable { get; set; }
 
-    public virtual bool ILLink { get; set; }
+    public virtual bool MergeIlLinkerFiles { get; set; }
 
     public virtual bool Internalize { get; set; }
 
@@ -118,7 +118,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
         if (ExcludeInternalizeSerializable)
             cmdParams.Add("/excludeinternalizeserializable");
 
-        if (ILLink)
+        if (MergeIlLinkerFiles)
             cmdParams.Add("/illink");
 
         if (Internalize)

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -54,7 +54,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual bool XmlDocumentation { get; set; }
 
-    public virtual bool ZeroPEKind { get; set; }
+    public virtual bool AllowZeroPeKind { get; set; }
 
     public virtual string TargetKind { get; set; } = string.Empty;
 
@@ -154,7 +154,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
         if (XmlDocumentation)
             cmdParams.Add("/xmldocs");
 
-        if (ZeroPEKind)
+        if (AllowZeroPeKind)
             cmdParams.Add("/zeropekind");
 
         if (!string.IsNullOrWhiteSpace(TargetKind))

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -20,7 +20,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual bool AllowDuplicateResources { get; set; }
 
-    public virtual bool AllowMultiple { get; set; }
+    public virtual bool AllowMultipleAssemblyLevelAttributes { get; set; }
 
     public virtual bool CopyAttrs { get; set; }
 
@@ -103,7 +103,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
         if (AllowDuplicateResources)
             cmdParams.Add("/allowduplicateresources");
 
-        if (AllowMultiple)
+        if (AllowMultipleAssemblyLevelAttributes)
             cmdParams.Add("/allowMultiple");
 
         if (CopyAttrs)

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -16,7 +16,7 @@ namespace KageKirin.ILRepack.Tool.MSBuild.Task;
 
 public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 {
-    public virtual bool AllowDup { get; set; }
+    public virtual bool AllowAllDuplicateTypes { get; set; }
 
     public virtual bool AllowDuplicateResources { get; set; }
 
@@ -97,7 +97,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
         var cmdParams = new List<string>();
 
-        if (AllowDup)
+        if (AllowAllDuplicateTypes)
             cmdParams.Add("/allowdup");
 
         if (AllowDuplicateResources)

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -52,7 +52,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual bool AllowWildCards { get; set; }
 
-    public virtual bool XmlDocs { get; set; }
+    public virtual bool XmlDocumentation { get; set; }
 
     public virtual bool ZeroPEKind { get; set; }
 
@@ -151,7 +151,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
         if (AllowWildCards)
             cmdParams.Add("/wildcards");
 
-        if (XmlDocs)
+        if (XmlDocumentation)
             cmdParams.Add("/xmldocs");
 
         if (ZeroPEKind)

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -46,7 +46,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual bool SkipConfigMerge { get; set; }
 
-    public virtual bool Union { get; set; }
+    public virtual bool UnionMerge { get; set; }
 
     public virtual bool Verbose { get; set; }
 
@@ -142,7 +142,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
         if (SkipConfigMerge)
             cmdParams.Add("/skipconfig");
 
-        if (Union)
+        if (UnionMerge)
             cmdParams.Add("/union");
 
         if (Verbose)

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -44,7 +44,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
     public virtual bool RenameInternalized { get; set; }
 
-    public virtual bool SkipConfig { get; set; }
+    public virtual bool SkipConfigMerge { get; set; }
 
     public virtual bool Union { get; set; }
 
@@ -139,7 +139,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
         if (RenameInternalized)
             cmdParams.Add("/renameinternalized");
 
-        if (SkipConfig)
+        if (SkipConfigMerge)
             cmdParams.Add("/skipconfig");
 
         if (Union)

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
@@ -58,9 +58,9 @@
     <ILRepackCopyAttrs Condition="'$(ILRepackCopyAttrs)' == 'disable'">false</ILRepackCopyAttrs>
     <ILRepackCopyAttrs Condition="'$(ILRepackCopyAttrs)' == 'enable'">true</ILRepackCopyAttrs>
 
-    <ILRepackAllowMultiple Condition="'$(ILRepackAllowMultiple)' == ''">false</ILRepackAllowMultiple>
-    <ILRepackAllowMultiple Condition="'$(ILRepackAllowMultiple)' == 'disable'">false</ILRepackAllowMultiple>
-    <ILRepackAllowMultiple Condition="'$(ILRepackAllowMultiple)' == 'enable'">true</ILRepackAllowMultiple>
+    <ILRepackAllowMultipleAssemblyLevelAttributes Condition="'$(ILRepackAllowMultipleAssemblyLevelAttributes)' == ''">false</ILRepackAllowMultipleAssemblyLevelAttributes>
+    <ILRepackAllowMultipleAssemblyLevelAttributes Condition="'$(ILRepackAllowMultipleAssemblyLevelAttributes)' == 'disable'">false</ILRepackAllowMultipleAssemblyLevelAttributes>
+    <ILRepackAllowMultipleAssemblyLevelAttributes Condition="'$(ILRepackAllowMultipleAssemblyLevelAttributes)' == 'enable'">true</ILRepackAllowMultipleAssemblyLevelAttributes>
 
     <ILRepackKeepOtherVersionReferences Condition="'$(ILRepackKeepOtherVersionReferences)' == ''">false</ILRepackKeepOtherVersionReferences>
     <ILRepackKeepOtherVersionReferences Condition="'$(ILRepackKeepOtherVersionReferences)' == 'disable'">false</ILRepackKeepOtherVersionReferences>

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
@@ -82,9 +82,9 @@
     <ILRepackXmlDocumentation Condition="'$(ILRepackXmlDocumentation)' == 'disable'">false</ILRepackXmlDocumentation>
     <ILRepackXmlDocumentation Condition="'$(ILRepackXmlDocumentation)' == 'enable'">true</ILRepackXmlDocumentation>
 
-    <ILRepackZeroPEKind Condition="'$(ILRepackZeroPEKind)' == ''">false</ILRepackZeroPEKind>
-    <ILRepackZeroPEKind Condition="'$(ILRepackZeroPEKind)' == 'disable'">false</ILRepackZeroPEKind>
-    <ILRepackZeroPEKind Condition="'$(ILRepackZeroPEKind)' == 'enable'">true</ILRepackZeroPEKind>
+    <ILRepackAllowZeroPeKind Condition="'$(ILRepackAllowZeroPeKind)' == ''">false</ILRepackAllowZeroPeKind>
+    <ILRepackAllowZeroPeKind Condition="'$(ILRepackAllowZeroPeKind)' == 'disable'">false</ILRepackAllowZeroPeKind>
+    <ILRepackAllowZeroPeKind Condition="'$(ILRepackAllowZeroPeKind)' == 'enable'">true</ILRepackAllowZeroPeKind>
 
     <ILRepackTimeout Condition="'$(ILRepackTimeout)' == ''">30</ILRepackTimeout>
     <ILRepackTimeout Condition="$([System.Int32]::TryParse('$(ILRepackTimeout)', null))">30</ILRepackTimeout>

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
@@ -78,9 +78,9 @@
     <ILRepackMergeIlLinkerFiles Condition="'$(ILRepackMergeIlLinkerFiles)' == 'disable'">false</ILRepackMergeIlLinkerFiles>
     <ILRepackMergeIlLinkerFiles Condition="'$(ILRepackMergeIlLinkerFiles)' == 'enable'">true</ILRepackMergeIlLinkerFiles>
 
-    <ILRepackXmlDocs Condition="'$(ILRepackXmlDocs)' == ''">false</ILRepackXmlDocs>
-    <ILRepackXmlDocs Condition="'$(ILRepackXmlDocs)' == 'disable'">false</ILRepackXmlDocs>
-    <ILRepackXmlDocs Condition="'$(ILRepackXmlDocs)' == 'enable'">true</ILRepackXmlDocs>
+    <ILRepackXmlDocumentation Condition="'$(ILRepackXmlDocumentation)' == ''">false</ILRepackXmlDocumentation>
+    <ILRepackXmlDocumentation Condition="'$(ILRepackXmlDocumentation)' == 'disable'">false</ILRepackXmlDocumentation>
+    <ILRepackXmlDocumentation Condition="'$(ILRepackXmlDocumentation)' == 'enable'">true</ILRepackXmlDocumentation>
 
     <ILRepackZeroPEKind Condition="'$(ILRepackZeroPEKind)' == ''">false</ILRepackZeroPEKind>
     <ILRepackZeroPEKind Condition="'$(ILRepackZeroPEKind)' == 'disable'">false</ILRepackZeroPEKind>

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
@@ -74,9 +74,9 @@
     <ILRepackSkipConfig Condition="'$(ILRepackSkipConfig)' == 'disable'">false</ILRepackSkipConfig>
     <ILRepackSkipConfig Condition="'$(ILRepackSkipConfig)' == 'enable'">true</ILRepackSkipConfig>
 
-    <ILRepackILLink Condition="'$(ILRepackILLink)' == ''">false</ILRepackILLink>
-    <ILRepackILLink Condition="'$(ILRepackILLink)' == 'disable'">false</ILRepackILLink>
-    <ILRepackILLink Condition="'$(ILRepackILLink)' == 'enable'">true</ILRepackILLink>
+    <ILRepackMergeIlLinkerFiles Condition="'$(ILRepackMergeIlLinkerFiles)' == ''">false</ILRepackMergeIlLinkerFiles>
+    <ILRepackMergeIlLinkerFiles Condition="'$(ILRepackMergeIlLinkerFiles)' == 'disable'">false</ILRepackMergeIlLinkerFiles>
+    <ILRepackMergeIlLinkerFiles Condition="'$(ILRepackMergeIlLinkerFiles)' == 'enable'">true</ILRepackMergeIlLinkerFiles>
 
     <ILRepackXmlDocs Condition="'$(ILRepackXmlDocs)' == ''">false</ILRepackXmlDocs>
     <ILRepackXmlDocs Condition="'$(ILRepackXmlDocs)' == 'disable'">false</ILRepackXmlDocs>

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
@@ -54,9 +54,9 @@
     <ILRepackNoRepackRes Condition="'$(ILRepackNoRepackRes)' == 'disable'">false</ILRepackNoRepackRes>
     <ILRepackNoRepackRes Condition="'$(ILRepackNoRepackRes)' == 'enable'">true</ILRepackNoRepackRes>
 
-    <ILRepackCopyAttrs Condition="'$(ILRepackCopyAttrs)' == ''">false</ILRepackCopyAttrs>
-    <ILRepackCopyAttrs Condition="'$(ILRepackCopyAttrs)' == 'disable'">false</ILRepackCopyAttrs>
-    <ILRepackCopyAttrs Condition="'$(ILRepackCopyAttrs)' == 'enable'">true</ILRepackCopyAttrs>
+    <ILRepackCopyAttributes Condition="'$(ILRepackCopyAttributes)' == ''">false</ILRepackCopyAttributes>
+    <ILRepackCopyAttributes Condition="'$(ILRepackCopyAttributes)' == 'disable'">false</ILRepackCopyAttributes>
+    <ILRepackCopyAttributes Condition="'$(ILRepackCopyAttributes)' == 'enable'">true</ILRepackCopyAttributes>
 
     <ILRepackAllowMultipleAssemblyLevelAttributes Condition="'$(ILRepackAllowMultipleAssemblyLevelAttributes)' == ''">false</ILRepackAllowMultipleAssemblyLevelAttributes>
     <ILRepackAllowMultipleAssemblyLevelAttributes Condition="'$(ILRepackAllowMultipleAssemblyLevelAttributes)' == 'disable'">false</ILRepackAllowMultipleAssemblyLevelAttributes>

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
@@ -26,9 +26,9 @@
     <ILRepackRenameInternalized Condition="'$(ILRepackRenameInternalized)' == 'disable'">false</ILRepackRenameInternalized>
     <ILRepackRenameInternalized Condition="'$(ILRepackRenameInternalized)' == 'enable'">true</ILRepackRenameInternalized>
 
-    <ILRepackWildcards Condition="'$(ILRepackWildcards)' == ''">false</ILRepackWildcards>
-    <ILRepackWildcards Condition="'$(ILRepackWildcards)' == 'disable'">false</ILRepackWildcards>
-    <ILRepackWildcards Condition="'$(ILRepackWildcards)' == 'enable'">true</ILRepackWildcards>
+    <ILRepackAllowWildCards Condition="'$(ILRepackAllowWildCards)' == ''">false</ILRepackAllowWildCards>
+    <ILRepackAllowWildCards Condition="'$(ILRepackAllowWildCards)' == 'disable'">false</ILRepackAllowWildCards>
+    <ILRepackAllowWildCards Condition="'$(ILRepackAllowWildCards)' == 'enable'">true</ILRepackAllowWildCards>
 
     <ILRepackDelaySign Condition="'$(ILRepackDelaySign)' == ''">false</ILRepackDelaySign>
     <ILRepackDelaySign Condition="'$(ILRepackDelaySign)' == 'disable'">false</ILRepackDelaySign>

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
@@ -42,9 +42,9 @@
     <ILRepackUnion Condition="'$(ILRepackUnion)' == 'disable'">false</ILRepackUnion>
     <ILRepackUnion Condition="'$(ILRepackUnion)' == 'enable'">true</ILRepackUnion>
 
-    <ILRepackAllowDup Condition="'$(ILRepackAllowDup)' == ''">false</ILRepackAllowDup>
-    <ILRepackAllowDup Condition="'$(ILRepackAllowDup)' == 'disable'">false</ILRepackAllowDup>
-    <ILRepackAllowDup Condition="'$(ILRepackAllowDup)' == 'enable'">true</ILRepackAllowDup>
+    <ILRepackAllowAllDuplicateTypes Condition="'$(ILRepackAllowAllDuplicateTypes)' == ''">false</ILRepackAllowAllDuplicateTypes>
+    <ILRepackAllowAllDuplicateTypes Condition="'$(ILRepackAllowAllDuplicateTypes)' == 'disable'">false</ILRepackAllowAllDuplicateTypes>
+    <ILRepackAllowAllDuplicateTypes Condition="'$(ILRepackAllowAllDuplicateTypes)' == 'enable'">true</ILRepackAllowAllDuplicateTypes>
 
     <ILRepackAllowDuplicateResources Condition="'$(ILRepackAllowDuplicateResources)' == ''">false</ILRepackAllowDuplicateResources>
     <ILRepackAllowDuplicateResources Condition="'$(ILRepackAllowDuplicateResources)' == 'disable'">false</ILRepackAllowDuplicateResources>

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
@@ -38,9 +38,9 @@
     <ILRepackExcludeInternalizeSerializable Condition="'$(ILRepackExcludeInternalizeSerializable)' == 'disable'">false</ILRepackExcludeInternalizeSerializable>
     <ILRepackExcludeInternalizeSerializable Condition="'$(ILRepackExcludeInternalizeSerializable)' == 'enable'">true</ILRepackExcludeInternalizeSerializable>
 
-    <ILRepackUnion Condition="'$(ILRepackUnion)' == ''">false</ILRepackUnion>
-    <ILRepackUnion Condition="'$(ILRepackUnion)' == 'disable'">false</ILRepackUnion>
-    <ILRepackUnion Condition="'$(ILRepackUnion)' == 'enable'">true</ILRepackUnion>
+    <ILRepackUnionMerge Condition="'$(ILRepackUnionMerge)' == ''">false</ILRepackUnionMerge>
+    <ILRepackUnionMerge Condition="'$(ILRepackUnionMerge)' == 'disable'">false</ILRepackUnionMerge>
+    <ILRepackUnionMerge Condition="'$(ILRepackUnionMerge)' == 'enable'">true</ILRepackUnionMerge>
 
     <ILRepackAllowAllDuplicateTypes Condition="'$(ILRepackAllowAllDuplicateTypes)' == ''">false</ILRepackAllowAllDuplicateTypes>
     <ILRepackAllowAllDuplicateTypes Condition="'$(ILRepackAllowAllDuplicateTypes)' == 'disable'">false</ILRepackAllowAllDuplicateTypes>

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
@@ -14,9 +14,9 @@
     <ILRepackDebugInfo Condition="'$(ILRepackDebugInfo)' == 'disable'">false</ILRepackDebugInfo>
     <ILRepackDebugInfo Condition="'$(ILRepackDebugInfo)' == 'enable'">true</ILRepackDebugInfo>
 
-    <ILRepackVerbose Condition="'$(ILRepackVerbose)' == ''">false</ILRepackVerbose>
-    <ILRepackVerbose Condition="'$(ILRepackVerbose)' == 'disable'">false</ILRepackVerbose>
-    <ILRepackVerbose Condition="'$(ILRepackVerbose)' == 'enable'">true</ILRepackVerbose>
+    <ILRepackLogVerbose Condition="'$(ILRepackLogVerbose)' == ''">false</ILRepackLogVerbose>
+    <ILRepackLogVerbose Condition="'$(ILRepackLogVerbose)' == 'disable'">false</ILRepackLogVerbose>
+    <ILRepackLogVerbose Condition="'$(ILRepackLogVerbose)' == 'enable'">true</ILRepackLogVerbose>
 
     <ILRepackInternalize Condition="'$(ILRepackInternalize)' == ''">false</ILRepackInternalize>
     <ILRepackInternalize Condition="'$(ILRepackInternalize)' == 'disable'">false</ILRepackInternalize>

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.props
@@ -70,9 +70,9 @@
     <ILRepackPreserveTimestamp Condition="'$(ILRepackPreserveTimestamp)' == 'disable'">false</ILRepackPreserveTimestamp>
     <ILRepackPreserveTimestamp Condition="'$(ILRepackPreserveTimestamp)' == 'enable'">true</ILRepackPreserveTimestamp>
 
-    <ILRepackSkipConfig Condition="'$(ILRepackSkipConfig)' == ''">false</ILRepackSkipConfig>
-    <ILRepackSkipConfig Condition="'$(ILRepackSkipConfig)' == 'disable'">false</ILRepackSkipConfig>
-    <ILRepackSkipConfig Condition="'$(ILRepackSkipConfig)' == 'enable'">true</ILRepackSkipConfig>
+    <ILRepackSkipConfigMerge Condition="'$(ILRepackSkipConfigMerge)' == ''">false</ILRepackSkipConfigMerge>
+    <ILRepackSkipConfigMerge Condition="'$(ILRepackSkipConfigMerge)' == 'disable'">false</ILRepackSkipConfigMerge>
+    <ILRepackSkipConfigMerge Condition="'$(ILRepackSkipConfigMerge)' == 'enable'">true</ILRepackSkipConfigMerge>
 
     <ILRepackMergeIlLinkerFiles Condition="'$(ILRepackMergeIlLinkerFiles)' == ''">false</ILRepackMergeIlLinkerFiles>
     <ILRepackMergeIlLinkerFiles Condition="'$(ILRepackMergeIlLinkerFiles)' == 'disable'">false</ILRepackMergeIlLinkerFiles>

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -74,7 +74,7 @@
       KeepOtherVersionReferences="$(ILRepackKeepOtherVersionReferences)"
       PreserveTimestamp="$(ILRepackPreserveTimestamp)"
       SkipConfig="$(ILRepackSkipConfig)"
-      ILLink="$(ILRepackILLink)"
+      MergeIlLinkerFiles="$(ILRepackMergeIlLinkerFiles)"
       XmlDocs="$(ILRepackXmlDocs)"
       ZeroPEKind="$(ILRepackZeroPEKind)"
       Timeout="$(ILRepackTimeout)"

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -59,7 +59,7 @@
     <ILRepack
       Parallel="$(ILRepackParallel)"
       DebugInfo="$(ILRepackDebugInfo)"
-      Verbose="$(ILRepackVerbose)"
+      LogVerbose="$(ILRepackLogVerbose)"
       Internalize="$(ILRepackInternalize)"
       RenameInternalized="$(ILRepackRenameInternalized)"
       Wildcards="$(ILRepackWildcards)"

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -73,7 +73,7 @@
       AllowMultipleAssemblyLevelAttributes="$(ILRepackAllowMultipleAssemblyLevelAttributes)"
       KeepOtherVersionReferences="$(ILRepackKeepOtherVersionReferences)"
       PreserveTimestamp="$(ILRepackPreserveTimestamp)"
-      SkipConfig="$(ILRepackSkipConfig)"
+      SkipConfigMerge="$(ILRepackSkipConfigMerge)"
       MergeIlLinkerFiles="$(ILRepackMergeIlLinkerFiles)"
       XmlDocs="$(ILRepackXmlDocs)"
       ZeroPEKind="$(ILRepackZeroPEKind)"

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -65,7 +65,7 @@
       Wildcards="$(ILRepackWildcards)"
       DelaySign="$(ILRepackDelaySign)"
       ExcludeInternalizeSerializable="$(ILRepackExcludeInternalizeSerializable)"
-      Union="$(ILRepackUnion)"
+      UnionMerge="$(ILRepackUnionMerge)"
       AllowAllDuplicateTypes="$(ILRepackAllowAllDuplicateTypes)"
       AllowDuplicateResources="$(ILRepackAllowDuplicateResources)"
       NoRepackRes="$(ILRepackNoRepackRes)"

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -62,7 +62,7 @@
       LogVerbose="$(ILRepackLogVerbose)"
       Internalize="$(ILRepackInternalize)"
       RenameInternalized="$(ILRepackRenameInternalized)"
-      Wildcards="$(ILRepackWildcards)"
+      AllowWildCards="$(ILRepackAllowWildCards)"
       DelaySign="$(ILRepackDelaySign)"
       ExcludeInternalizeSerializable="$(ILRepackExcludeInternalizeSerializable)"
       UnionMerge="$(ILRepackUnionMerge)"

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -75,7 +75,7 @@
       PreserveTimestamp="$(ILRepackPreserveTimestamp)"
       SkipConfigMerge="$(ILRepackSkipConfigMerge)"
       MergeIlLinkerFiles="$(ILRepackMergeIlLinkerFiles)"
-      XmlDocs="$(ILRepackXmlDocs)"
+      XmlDocumentation="$(ILRepackXmlDocumentation)"
       ZeroPEKind="$(ILRepackZeroPEKind)"
       Timeout="$(ILRepackTimeout)"
       Version="$(ILRepackVersion)"

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -76,7 +76,7 @@
       SkipConfigMerge="$(ILRepackSkipConfigMerge)"
       MergeIlLinkerFiles="$(ILRepackMergeIlLinkerFiles)"
       XmlDocumentation="$(ILRepackXmlDocumentation)"
-      ZeroPEKind="$(ILRepackZeroPEKind)"
+      AllowZeroPeKind="$(ILRepackAllowZeroPeKind)"
       Timeout="$(ILRepackTimeout)"
       Version="$(ILRepackVersion)"
       TargetKind="$(ILRepackTargetKind)"

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -70,7 +70,7 @@
       AllowDuplicateResources="$(ILRepackAllowDuplicateResources)"
       NoRepackRes="$(ILRepackNoRepackRes)"
       CopyAttrs="$(ILRepackCopyAttrs)"
-      AllowMultiple="$(ILRepackAllowMultiple)"
+      AllowMultipleAssemblyLevelAttributes="$(ILRepackAllowMultipleAssemblyLevelAttributes)"
       KeepOtherVersionReferences="$(ILRepackKeepOtherVersionReferences)"
       PreserveTimestamp="$(ILRepackPreserveTimestamp)"
       SkipConfig="$(ILRepackSkipConfig)"

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -69,7 +69,7 @@
       AllowAllDuplicateTypes="$(ILRepackAllowAllDuplicateTypes)"
       AllowDuplicateResources="$(ILRepackAllowDuplicateResources)"
       NoRepackRes="$(ILRepackNoRepackRes)"
-      CopyAttrs="$(ILRepackCopyAttrs)"
+      CopyAttributes="$(ILRepackCopyAttributes)"
       AllowMultipleAssemblyLevelAttributes="$(ILRepackAllowMultipleAssemblyLevelAttributes)"
       KeepOtherVersionReferences="$(ILRepackKeepOtherVersionReferences)"
       PreserveTimestamp="$(ILRepackPreserveTimestamp)"

--- a/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
+++ b/ILRepack.Tool.MSBuild.Task/build/KageKirin.ILRepack.Tool.MSBuild.Task.targets
@@ -66,7 +66,7 @@
       DelaySign="$(ILRepackDelaySign)"
       ExcludeInternalizeSerializable="$(ILRepackExcludeInternalizeSerializable)"
       Union="$(ILRepackUnion)"
-      AllowDup="$(ILRepackAllowDup)"
+      AllowAllDuplicateTypes="$(ILRepackAllowAllDuplicateTypes)"
       AllowDuplicateResources="$(ILRepackAllowDuplicateResources)"
       NoRepackRes="$(ILRepackNoRepackRes)"
       CopyAttrs="$(ILRepackCopyAttrs)"

--- a/Tests/Repack.Lib.RefOnly.Test/ILRepack.targets
+++ b/Tests/Repack.Lib.RefOnly.Test/ILRepack.targets
@@ -25,7 +25,7 @@
     <ILRepack
       Parallel="false"
       DebugInfo="true"
-      Verbose="false"
+      LogVerbose="false"
       Internalize="true"
       RenameInternalized="false"
       InputAssemblies="@(MainAssembly);@(InputAssemblies)"

--- a/Tests/Repack.Lib.Test/ILRepack.targets
+++ b/Tests/Repack.Lib.Test/ILRepack.targets
@@ -25,7 +25,7 @@
     <ILRepack
       Parallel="false"
       DebugInfo="true"
-      Verbose="false"
+      LogVerbose="false"
       Internalize="true"
       RenameInternalized="false"
       InputAssemblies="@(MainAssembly);@(InputAssemblies)"

--- a/Tests/Repack.Tool.RefOnly.Test/ILRepack.targets
+++ b/Tests/Repack.Tool.RefOnly.Test/ILRepack.targets
@@ -25,7 +25,7 @@
     <ILRepack
       Parallel="false"
       DebugInfo="true"
-      Verbose="false"
+      LogVerbose="false"
       Internalize="true"
       RenameInternalized="false"
       InputAssemblies="@(MainAssembly);@(InputAssemblies)"

--- a/Tests/Repack.Tool.Test/ILRepack.targets
+++ b/Tests/Repack.Tool.Test/ILRepack.targets
@@ -25,7 +25,7 @@
     <ILRepack
       Parallel="false"
       DebugInfo="true"
-      Verbose="false"
+      LogVerbose="false"
       Internalize="true"
       RenameInternalized="false"
       InputAssemblies="@(MainAssembly);@(InputAssemblies)"


### PR DESCRIPTION
- **refactor: rename ILRepack property `AllowDup` -> `AllowAllDuplicateTypes`**
- **refactor: rename ILRepack property `AllowMultiple` -> `AllowMultipleAssemblyLevelAttributes`**
- **refactor: rename ILRepack property `CopyAttrs` -> `CopyAttributes`**
- **refactor: rename ILRepack property `ILLink` -> `MergeIlLinkerFiles`**
- **refactor: rename ILRepack property `SkipConfig` -> `SkipConfigMerge`**
- **refactor: rename ILRepack property `Union` -> `UnionMerge`**
- **refactor: rename ILRepack property `Verbose` -> `LogVerbose`**
- **refactor: rename ILRepack property `Wildcards` -> `AllowWildCards`**
- **refactor: rename ILRepack property `XmlDocs` -> `XmlDocumentation`**
- **refactor: rename ILRepack property `ZeroPEKind` -> `AllowZeroPeKind`**
