### PR TITLE
fix: resolve warnings during ILRepack step for ILRepack.Lib.MSBuild.Task

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepack.not
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.not
@@ -5,3 +5,4 @@ Microsoft.Build
 Microsoft.Build.Framework
 Microsoft.Build.Utilities.Core
 Mono.Cecil
+Mono.Cecil.Pdb

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.targets
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.targets
@@ -7,7 +7,7 @@
       <_ThisAssembly>$(IntermediateOutputPath)$(TargetFileName)</_ThisAssembly>
       <_ILRepackAssembly>$(PkgILRepack_Lib)/lib/net472/ILRepack.dll</_ILRepackAssembly>
       <_ILRepackLibs>/lib:$(PkgMicrosoft_Build_Utilities_Core)\lib\net472 /lib:$(PkgMicrosoft_Build_Framework)\lib\net472</_ILRepackLibs>
-      <_ILRepackExclude>ILRepack.not</_ILRepackExclude>
+      <_ILRepackExclude>$(MSBuildThisFileDirectory)ILRepack.not</_ILRepackExclude>
       <_ILRepackExe>$(PkgILRepack)/tools/ILRepack.exe</_ILRepackExe>
       <_ILRepackCmd>$(_ILRepackExe) /internalize:$(_ILRepackExclude) /renameinternalized $(_ILRepackLibs) /log:$(_ThisAssembly).ilrepack.log /out:$(_ThisAssembly).repack $(_ThisAssembly) $(_ILRepackAssembly)</_ILRepackCmd>
     </PropertyGroup>


### PR DESCRIPTION
- **build: indicate correct path to `ILRepack.not` in ILRepack.targets**
- **build: add Mono.Cecil.Pdb to `ILRepack.not`**
