### PR TITLE
refactor: use absolute assembly paths

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -302,7 +302,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
         Log.LogMessage(MessageImportance.High, $"ILRepackLib: repackOptions {repackOptions}");
 
         // create output dir
-        string outputPath = Path.GetDirectoryName(OutputFile.ItemSpec);
+        string outputPath = Path.GetDirectoryName(Path.GetFullPath(OutputFile.ItemSpec));
         if (outputPath != null && !Directory.Exists(outputPath))
         {
             try

--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -293,7 +293,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
                 .Distinct();
 
         repackOptions.OutputFile = outputAssembly;
-        repackOptions.InputAssemblies = [.. InputAssemblies.Select(f => f.ItemSpec).Distinct()];
+        repackOptions.InputAssemblies = [.. InputAssemblies.Select(f => Path.GetFullPath(f.ItemSpec)).Distinct()];
 
         Log.LogMessage(
             MessageImportance.High,

--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -286,10 +286,10 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
         }
 
         if (LibraryPaths is not null && LibraryPaths.Length > 0)
-            repackOptions.SearchDirectories = LibraryPaths.Select(item => item.ItemSpec).Distinct();
+            repackOptions.SearchDirectories = LibraryPaths.Select(item => Path.GetFullPath(item.ItemSpec)).Distinct();
         else
             repackOptions.SearchDirectories = InputAssemblies
-                .Select(item => Path.GetDirectoryName(item.ItemSpec))
+                .Select(item => Path.GetDirectoryName(Path.GetFullPath(item.ItemSpec)))
                 .Distinct();
 
         repackOptions.OutputFile = outputAssembly;

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -286,7 +286,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
             );
 
         if (!string.IsNullOrWhiteSpace(OutputFile.ItemSpec))
-            cmdParams.Add($"/out:\"{OutputFile.ItemSpec}\"");
+            cmdParams.Add($"/out:\"{Path.GetFullPath(OutputFile.ItemSpec)}\"");
 
         // must come last
         cmdParams.AddRange(InputAssemblies.Select(item => Path.GetFullPath(item.ItemSpec)).Distinct());

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -275,12 +275,12 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
 
         if (LibraryPaths is not null && LibraryPaths.Length > 0)
             cmdParams.AddRange(
-                LibraryPaths.Select(item => item.ItemSpec).Select(l => $"/lib:\"{l}\"").Distinct()
+                LibraryPaths.Select(item => Path.GetFullPath(item.ItemSpec)).Select(l => $"/lib:\"{l}\"").Distinct()
             );
         else
             cmdParams.AddRange(
                 InputAssemblies
-                    .Select(item => Path.GetDirectoryName(item.ItemSpec))
+                    .Select(item => Path.GetDirectoryName(Path.GetFullPath(item.ItemSpec)))
                     .Select(l => $"/lib:\"{l}\"")
                     .Distinct()
             );

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -289,7 +289,7 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
             cmdParams.Add($"/out:\"{OutputFile.ItemSpec}\"");
 
         // must come last
-        cmdParams.AddRange(InputAssemblies.Select(item => item.ItemSpec).Distinct());
+        cmdParams.AddRange(InputAssemblies.Select(item => Path.GetFullPath(item.ItemSpec)).Distinct());
 
         var thisPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
         var ilrepack = Path.Combine(thisPath, "tools", "ILRepack.exe");


### PR DESCRIPTION
- **refactor: use absolute library search paths**
- **refactor: use absolute path for input assemblies**
- **refactor: use absolute path for output assembly**
