### PR TITLE
refactor: construct more comprehensive list of ILRepack library search paths by considering all inputs

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepackLib.cs
@@ -546,6 +546,16 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
             repackOptions.ExcludeFile = excludeFile;
         }
 
+        repackOptions.SearchDirectories = InputAssemblies
+            .Select(item => Path.GetDirectoryName(Path.GetFullPath(item.ItemSpec)))
+            .Distinct();
+        if (LibraryPaths is not null && LibraryPaths.Length > 0)
+            repackOptions.SearchDirectories = repackOptions
+                .SearchDirectories.Concat(
+                    LibraryPaths.Select(item => Path.GetFullPath(item.ItemSpec))
+                )
+                .Distinct();
+
         Log.LogMessage(
             MessageImportance.Low,
             $"ILRepackLib: InputAssemblies (unfiltered): {string.Join("\n", InputAssemblies.Select(f => f.ItemSpec))}"
@@ -591,16 +601,6 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
                 Log.LogError($"ILRepackLib: InputAssemblies `{inputAssembly}` does not exist!");
             }
         }
-
-        repackOptions.SearchDirectories = InputAssemblies
-            .Select(item => Path.GetDirectoryName(Path.GetFullPath(item.ItemSpec)))
-            .Distinct();
-        if (LibraryPaths is not null && LibraryPaths.Length > 0)
-            repackOptions.SearchDirectories = repackOptions
-                .SearchDirectories.Concat(
-                    LibraryPaths.Select(item => Path.GetFullPath(item.ItemSpec))
-                )
-                .Distinct();
 
         repackOptions.OutputFile = outputAssembly;
         repackOptions.InputAssemblies = [.. InputAssemblies.Select(f => Path.GetFullPath(f.ItemSpec)).Distinct()];

--- a/ILRepack.Tool.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Tool.MSBuild.Task/ILRepack.cs
@@ -555,6 +555,18 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
                 RepackDropAttributes.Select(attr => $"/repackdrop:\"{attr.ItemSpec}\"")
             );
 
+        IEnumerable<string> searchDirectories = InputAssemblies
+            .Select(item => Path.GetDirectoryName(Path.GetFullPath(item.ItemSpec)))
+            .Distinct();
+        if (LibraryPaths is not null && LibraryPaths.Length > 0)
+            searchDirectories = searchDirectories
+                .Concat(LibraryPaths.Select(item => Path.GetFullPath(item.ItemSpec)))
+                .Distinct();
+
+        cmdParams.AddRange(
+            searchDirectories.Select(item => Path.GetFullPath(item)).Select(l => $"/lib:\"{l}\"")
+        );
+
         Log.LogMessage(
             MessageImportance.Low,
             $"ILRepack: InputAssemblies (unfiltered): {string.Join("\n", InputAssemblies.Select(f => f.ItemSpec))}"
@@ -578,18 +590,6 @@ public class ILRepack : Microsoft.Build.Utilities.Task, IDisposable
         Log.LogMessage(
             MessageImportance.Low,
             $"ILRepack: InputAssemblies (filtered): {string.Join("\n", InputAssemblies.Distinct().Select(f => f.ItemSpec))}"
-        );
-
-        IEnumerable<string> searchDirectories = InputAssemblies
-            .Select(item => Path.GetDirectoryName(Path.GetFullPath(item.ItemSpec)))
-            .Distinct();
-        if (LibraryPaths is not null && LibraryPaths.Length > 0)
-            searchDirectories = searchDirectories
-                .Concat(LibraryPaths.Select(item => Path.GetFullPath(item.ItemSpec)))
-                .Distinct();
-
-        cmdParams.AddRange(
-            searchDirectories.Select(item => Path.GetFullPath(item)).Select(l => $"/lib:\"{l}\"")
         );
 
         if (!string.IsNullOrWhiteSpace(OutputFile.ItemSpec))


### PR DESCRIPTION
- **refactor: unconditionally reference input assembly directories as library paths**
- **refactor: use unfiltered input assembly paths for library paths**
