### PR TITLE
build: explicitly include ILRepack.Lib assembly in ILRepack.Lib.MSBuild.Task

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepack.Config.props
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.Config.props
@@ -9,6 +9,7 @@
   <ItemGroup>
     <ILRepackInputAssemblies Include="$(PkgMicrosoft_Build_Utilities_Core)\lib\net472\*.dll" />
     <ILRepackInputAssemblies Include="$(PkgMicrosoft_Build_Framework)\lib\net472\*.dll" />
+    <ILRepackInputAssemblies Include="$(PkgILRepack_Lib)\lib\net472\*.dll" />
 
     <ILRepackInternalizeExclude Include="Microsoft.Win32.dll" />
     <ILRepackInternalizeExclude Include="System.dll" />

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.Config.props
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.Config.props
@@ -19,6 +19,8 @@
     <ILRepackInternalizeExclude Include="Microsoft.Build.Utilities.Core.dll" />
     <ILRepackInternalizeExclude Include="Mono.Cecil.dll" />
     <ILRepackInternalizeExclude Include="ILRepack.Tool.MSBuild.Task.dll" />
+
+    <ILRepackFilterAssemblies Include="ILRepack" />
   </ItemGroup>
 
 </Project>

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.Config.props
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.Config.props
@@ -11,14 +11,15 @@
     <ILRepackInputAssemblies Include="$(PkgMicrosoft_Build_Framework)\lib\net472\*.dll" />
     <ILRepackInputAssemblies Include="$(PkgILRepack_Lib)\lib\net472\*.dll" />
 
-    <ILRepackInternalizeExclude Include="Microsoft.Win32.dll" />
-    <ILRepackInternalizeExclude Include="System.dll" />
-    <ILRepackInternalizeExclude Include="System.IO.dll" />
-    <ILRepackInternalizeExclude Include="Microsoft.Build.dll" />
-    <ILRepackInternalizeExclude Include="Microsoft.Build.Framework.dll" />
-    <ILRepackInternalizeExclude Include="Microsoft.Build.Utilities.Core.dll" />
-    <ILRepackInternalizeExclude Include="Mono.Cecil.dll" />
-    <ILRepackInternalizeExclude Include="ILRepack.Tool.MSBuild.Task.dll" />
+    <ILRepackInternalizeExclude Include="Microsoft.Win32" />
+    <ILRepackInternalizeExclude Include="System" />
+    <ILRepackInternalizeExclude Include="System.IO" />
+    <ILRepackInternalizeExclude Include="Microsoft.Build" />
+    <ILRepackInternalizeExclude Include="Microsoft.Build.Framework" />
+    <ILRepackInternalizeExclude Include="Microsoft.Build.Utilities.Core" />
+    <ILRepackInternalizeExclude Include="Mono.Cecil" />
+    <ILRepackInternalizeExclude Include="Mono.Cecil.Cil" />
+    <ILRepackInternalizeExclude Include="Mono.Cecil.Pdb" />
 
     <ILRepackFilterAssemblies Include="ILRepack" />
   </ItemGroup>


### PR DESCRIPTION
- **build: explicitly include ILRepack.Lib assembly in ILRepackInputAssemblies items**
- **build: add 'ILRepack' to ILRepackFilterAssemblies items**
- **build: port former entries in ILRepack.not to ILRepackInternalizeExclude items**